### PR TITLE
Phase two: Refactored AMQPClient to match EventHubsClientWrapper

### DIFF
--- a/core/src/main/scala/org/apache/spark/eventhubscommon/client/Client.scala
+++ b/core/src/main/scala/org/apache/spark/eventhubscommon/client/Client.scala
@@ -23,9 +23,8 @@ import org.apache.spark.eventhubscommon.client.EventHubsOffsetTypes.EventHubsOff
 
 private[spark] trait Client extends Serializable {
 
-  private[spark] var client: EventHubClient = _
+  private[spark] var client: EventHubClient
 
-  // TODO can we get rid of EventData with type parameters?
   def receive(expectedEvents: Int): Iterable[EventData]
 
   private[spark] def initClient(): Unit
@@ -38,25 +37,19 @@ private[spark] trait Client extends Serializable {
    * return the start seq number of each partition
    * @return a map from eventhubName-partition to seq
    */
-  def startSeqOfPartition(retryIfFail: Boolean,
-                          targetEventHubNameAndPartitions: List[EventHubNameAndPartition] = List())
-    : Option[Map[EventHubNameAndPartition, Long]]
+  def startSeqOfPartition(eventHubNameAndPartition: EventHubNameAndPartition): Option[Long]
 
   /**
    * return the end point of each partition
    * @return a map from eventhubName-partition to (offset, seq)
    */
-  def endPointOfPartition(retryIfFail: Boolean,
-                          targetEventHubNameAndPartitions: List[EventHubNameAndPartition] = List())
-    : Option[Map[EventHubNameAndPartition, (Long, Long)]]
+  def endPointOfPartition(eventHubNameAndPartition: EventHubNameAndPartition): Option[(Long, Long)]
 
   /**
    * return the last enqueueTime of each partition
    * @return a map from eventHubsNamePartition to EnqueueTime
    */
-  def lastEnqueueTimeOfPartitions(retryIfFail: Boolean,
-                                  targetEventHubNameAndPartitions: List[EventHubNameAndPartition])
-    : Option[Map[EventHubNameAndPartition, Long]]
+  def lastEnqueueTimeOfPartitions(eventHubNameAndPartition: EventHubNameAndPartition): Option[Long]
 
   /**
    * close this client

--- a/core/src/main/scala/org/apache/spark/eventhubscommon/client/EventHubsClientWrapper.scala
+++ b/core/src/main/scala/org/apache/spark/eventhubscommon/client/EventHubsClientWrapper.scala
@@ -33,6 +33,10 @@ private[spark] class EventHubsClientWrapper(private val ehParams: Map[String, St
     with Client
     with Logging {
 
+  // AMQPClient stuff
+
+  // EventHubsClientWrapper stuff
+  override private[spark] var client: EventHubClient = _
   private[spark] var partitionReceiver: PartitionReceiver = _
 
   /* Extract relevant info from ehParams */
@@ -82,9 +86,8 @@ private[spark] class EventHubsClientWrapper(private val ehParams: Map[String, St
     if (client != null) client.closeSync()
   }
 
-  override def endPointOfPartition(retryIfFail: Boolean,
-                                   targetEventHubsNameAndPartitions: List[EventHubNameAndPartition])
-    : Option[Map[EventHubNameAndPartition, (Long, Long)]] = {
+  override def endPointOfPartition(
+      eventHubNameAndPartition: EventHubNameAndPartition): Option[(Long, Long)] = {
     throw new UnsupportedOperationException(
       "endPointOfPartition is not supported by this client" +
         " yet, please use AMQPEventHubsClient")
@@ -96,9 +99,7 @@ private[spark] class EventHubsClientWrapper(private val ehParams: Map[String, St
    * @return a map from eventHubsNamePartition to EnqueueTime
    */
   override def lastEnqueueTimeOfPartitions(
-      retryIfFail: Boolean,
-      targetEventHubNameAndPartitions: List[EventHubNameAndPartition])
-    : Option[Map[EventHubNameAndPartition, Long]] = {
+      eventHubNameAndPartition: EventHubNameAndPartition): Option[Long] = {
     throw new UnsupportedOperationException(
       "lastEnqueueTimeOfPartitions is not supported by this" +
         " client yet, please use AMQPEventHubsClient")
@@ -109,9 +110,8 @@ private[spark] class EventHubsClientWrapper(private val ehParams: Map[String, St
    *
    * @return a map from eventhubName-partition to seq
    */
-  override def startSeqOfPartition(retryIfFail: Boolean,
-                                   targetEventHubNameAndPartitions: List[EventHubNameAndPartition])
-    : Option[Map[EventHubNameAndPartition, Long]] = {
+  override def startSeqOfPartition(
+      eventHubNameAndPartition: EventHubNameAndPartition): Option[Long] = {
     throw new UnsupportedOperationException(
       "startSeqOfPartition is not supported by this client" +
         " yet, please use AMQPEventHubsClient")

--- a/core/src/main/scala/org/apache/spark/sql/streaming/eventhubs/EventHubsSourceProvider.scala
+++ b/core/src/main/scala/org/apache/spark/sql/streaming/eventhubs/EventHubsSourceProvider.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.streaming.eventhubs
 
-import org.apache.spark.eventhubscommon.client.EventHubsClientWrapper
+import org.apache.spark.eventhubscommon.client.{ AMQPEventHubsClient, EventHubsClientWrapper }
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.SQLContext
 import org.apache.spark.sql.execution.streaming.Source
@@ -45,7 +45,10 @@ private[sql] class EventHubsSourceProvider
                             parameters: Map[String, String]): Source = {
     // TODO: use serviceLoader to pass in customized eventhubReceiverCreator and
     // eventhubClientCreator
-    new EventHubsSource(sqlContext, parameters, EventHubsClientWrapper.apply)
+    new EventHubsSource(sqlContext,
+                        parameters,
+                        EventHubsClientWrapper.apply,
+                        AMQPEventHubsClient.apply)
   }
 }
 

--- a/core/src/main/scala/org/apache/spark/streaming/eventhubs/EventHubsUtils.scala
+++ b/core/src/main/scala/org/apache/spark/streaming/eventhubs/EventHubsUtils.scala
@@ -18,7 +18,11 @@ package org.apache.spark.streaming.eventhubs
 
 import com.microsoft.azure.eventhubs.EventData
 import org.apache.spark.SparkConf
-import org.apache.spark.eventhubscommon.client.{ Client, EventHubsClientWrapper }
+import org.apache.spark.eventhubscommon.client.{
+  AMQPEventHubsClient,
+  Client,
+  EventHubsClientWrapper
+}
 import org.apache.spark.streaming.StreamingContext
 
 object EventHubsUtils {
@@ -51,7 +55,8 @@ object EventHubsUtils {
                                               eventHubNamespace,
                                               progressDir,
                                               eventParams,
-                                              EventHubsClientWrapper.apply)
+                                              EventHubsClientWrapper.apply,
+                                              AMQPEventHubsClient.apply)
     newStream
   }
 
@@ -64,8 +69,7 @@ object EventHubsUtils {
       eventHubNamespace: String,
       progressDir: String,
       eventParams: Predef.Map[String, Predef.Map[String, String]],
-      eventHubsClientCreator: (String, Predef.Map[String, Predef.Map[String, String]]) => Client)
-    : EventHubDirectDStream = {
+      eventHubsClientCreator: (Map[String, String]) => Client): EventHubDirectDStream = {
     val newStream = new EventHubDirectDStream(ssc,
                                               eventHubNamespace,
                                               progressDir,

--- a/core/src/test/scala/org/apache/spark/sql/streaming/eventhubs/EventHubsSourceSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/streaming/eventhubs/EventHubsSourceSuite.scala
@@ -79,8 +79,7 @@ class EventHubsSourceSuite extends EventHubsStreamTest with MockitoSugar {
       spark.sqlContext,
       eventHubsParameters,
       (_: Map[String, String]) => new TestEventHubsReceiver(eventHubsParameters, eventHubs),
-      (_: String, _: Map[String, Map[String, String]]) =>
-        new TestRestEventHubClient(highestOffsetPerPartition)
+      (_: Map[String, String]) => new TestRestEventHubClient(highestOffsetPerPartition)
     )
     val offset = eventHubsSource.getOffset.get.asInstanceOf[EventHubsBatchRecord]
     assert(offset.batchId == 0)
@@ -97,8 +96,7 @@ class EventHubsSourceSuite extends EventHubsStreamTest with MockitoSugar {
       spark.sqlContext,
       eventHubsParameters,
       (_: Map[String, String]) => new TestEventHubsReceiver(eventHubsParameters, eventHubs),
-      (_: String, _: Map[String, Map[String, String]]) =>
-        new TestRestEventHubClient(highestOffsetPerPartition)
+      (_: Map[String, String]) => new TestRestEventHubClient(highestOffsetPerPartition)
     )
     val offset = eventHubsSource.getOffset.get.asInstanceOf[EventHubsBatchRecord]
     assert(offset.batchId == 0)
@@ -117,8 +115,7 @@ class EventHubsSourceSuite extends EventHubsStreamTest with MockitoSugar {
       spark.sqlContext,
       ehParams,
       (_: Map[String, String]) => new TestEventHubsReceiver(ehParams, eventHubs),
-      (_: String, _: Map[String, Map[String, String]]) =>
-        new TestRestEventHubClient(highestOffsetPerPartition)
+      (_: Map[String, String]) => new TestRestEventHubClient(highestOffsetPerPartition)
     )
     // First batch
     var offset = eventHubsSource.getOffset.get.asInstanceOf[EventHubsBatchRecord]
@@ -146,8 +143,7 @@ class EventHubsSourceSuite extends EventHubsStreamTest with MockitoSugar {
       spark.sqlContext,
       eventHubsParameters,
       (_: Map[String, String]) => new TestEventHubsReceiver(eventHubsParameters, eventHubs),
-      (_: String, _: Map[String, Map[String, String]]) =>
-        new TestRestEventHubClient(highestOffsetPerPartition)
+      (_: Map[String, String]) => new TestRestEventHubClient(highestOffsetPerPartition)
     )
     val offset = eventHubsSource.getOffset.get.asInstanceOf[EventHubsBatchRecord]
     val dataFrame = eventHubsSource.getBatch(None, offset)
@@ -166,8 +162,7 @@ class EventHubsSourceSuite extends EventHubsStreamTest with MockitoSugar {
       spark.sqlContext,
       eventHubsParameters,
       (_: Map[String, String]) => new TestEventHubsReceiver(eventHubsParameters, eventHubs),
-      (_: String, _: Map[String, Map[String, String]]) =>
-        new TestRestEventHubClient(highestOffsetPerPartition)
+      (_: Map[String, String]) => new TestRestEventHubClient(highestOffsetPerPartition)
     )
     val offset = eventHubsSource.getOffset.get.asInstanceOf[EventHubsBatchRecord]
     val dataFrame = eventHubsSource.getBatch(None, offset)
@@ -188,8 +183,7 @@ class EventHubsSourceSuite extends EventHubsStreamTest with MockitoSugar {
       spark.sqlContext,
       eventHubsParameters,
       (_: Map[String, String]) => new TestEventHubsReceiver(eventHubsParameters, eventHubs),
-      (_: String, _: Map[String, Map[String, String]]) =>
-        new TestRestEventHubClient(highestOffsetPerPartition)
+      (_: Map[String, String]) => new TestRestEventHubClient(highestOffsetPerPartition)
     )
     // First batch
     var offset = eventHubsSource.getOffset.get.asInstanceOf[EventHubsBatchRecord]
@@ -225,8 +219,7 @@ class EventHubsSourceSuite extends EventHubsStreamTest with MockitoSugar {
       spark.sqlContext,
       eventHubsParameters,
       (_: Map[String, String]) => new TestEventHubsReceiver(eventHubsParameters, eventHubs),
-      (_: String, _: Map[String, Map[String, String]]) =>
-        new TestRestEventHubClient(highestOffsetPerPartition)
+      (_: Map[String, String]) => new TestRestEventHubClient(highestOffsetPerPartition)
     )
     val offset = eventHubsSource.getOffset.get.asInstanceOf[EventHubsBatchRecord]
     val dataFrame = eventHubsSource.getBatch(None, offset)
@@ -268,8 +261,7 @@ class EventHubsSourceSuite extends EventHubsStreamTest with MockitoSugar {
       spark.sqlContext,
       eventHubsParameters,
       (_: Map[String, String]) => new TestEventHubsReceiver(eventHubsParameters, eventHubs),
-      (_: String, _: Map[String, Map[String, String]]) =>
-        new TestRestEventHubClient(highestOffsetPerPartition)
+      (_: Map[String, String]) => new TestRestEventHubClient(highestOffsetPerPartition)
     )
     val offset = eventHubsSource.getOffset.get.asInstanceOf[EventHubsBatchRecord]
     val dataFrame = eventHubsSource.getBatch(None, offset)
@@ -290,8 +282,7 @@ class EventHubsSourceSuite extends EventHubsStreamTest with MockitoSugar {
       spark.sqlContext,
       eventHubsParameters,
       (_: Map[String, String]) => new TestEventHubsReceiver(eventHubsParameters, eventHubs),
-      (_: String, _: Map[String, Map[String, String]]) =>
-        new TestRestEventHubClient(highestOffsetPerPartition)
+      (_: Map[String, String]) => new TestRestEventHubClient(highestOffsetPerPartition)
     )
     val offset = eventHubsSource.getOffset.get.asInstanceOf[EventHubsBatchRecord]
     val dataFrame = eventHubsSource.getBatch(None, offset)
@@ -317,8 +308,7 @@ class EventHubsSourceSuite extends EventHubsStreamTest with MockitoSugar {
       spark.sqlContext,
       eventHubsParameters,
       (_: Map[String, String]) => new TestEventHubsReceiver(eventHubsParameters, eventHubs),
-      (_: String, _: Map[String, Map[String, String]]) =>
-        new TestRestEventHubClient(highestOffsetPerPartition)
+      (_: Map[String, String]) => new TestRestEventHubClient(highestOffsetPerPartition)
     )
     val offset = eventHubsSource.getOffset.get.asInstanceOf[EventHubsBatchRecord]
     val dataFrame = eventHubsSource.getBatch(None, offset)
@@ -344,8 +334,7 @@ class EventHubsSourceSuite extends EventHubsStreamTest with MockitoSugar {
       spark.sqlContext,
       eventHubsParameters,
       (_: Map[String, String]) => new TestEventHubsReceiver(eventHubsParameters, eventHubs),
-      (_: String, _: Map[String, Map[String, String]]) =>
-        new TestRestEventHubClient(highestOffsetPerPartition)
+      (_: Map[String, String]) => new TestRestEventHubClient(highestOffsetPerPartition)
     )
     val offset = eventHubsSource.getOffset.get.asInstanceOf[EventHubsBatchRecord]
     val dataFrame = eventHubsSource.getBatch(None, offset)

--- a/core/src/test/scala/org/apache/spark/streaming/eventhubs/EventHubTestSuiteBase.scala
+++ b/core/src/test/scala/org/apache/spark/streaming/eventhubs/EventHubTestSuiteBase.scala
@@ -110,8 +110,7 @@ private[eventhubs] trait EventHubTestSuiteBase extends TestSuiteBase {
       progressRootPath.toString,
       eventhubsParams,
       (ehParams: Map[String, String]) => new TestEventHubsReceiver(ehParams, simulatedEventHubs),
-      (_: String, _: Map[String, Map[String, String]]) =>
-        FragileEventHubClient.getInstance("", Map())
+      (_: Map[String, String]) => FragileEventHubClient.getInstance("", Map())
     )
   }
 
@@ -157,8 +156,7 @@ private[eventhubs] trait EventHubTestSuiteBase extends TestSuiteBase {
       progressRootPath.toString,
       eventhubsParams,
       (ehParams: Map[String, String]) => new TestEventHubsReceiver(ehParams, simulatedEventHubs),
-      (_: String, _: Map[String, Map[String, String]]) =>
-        new TestRestEventHubClient(maxOffsetForEachEventHub)
+      (_: Map[String, String]) => new TestRestEventHubClient(maxOffsetForEachEventHub)
     )
   }
 
@@ -337,7 +335,7 @@ private[eventhubs] trait EventHubTestSuiteBase extends TestSuiteBase {
       progressRootPath.toString,
       eventhubsParams,
       (ehParams: Map[String, String]) => new TestEventHubsReceiver(ehParams, simulatedEventHubs),
-      (_: String, _: Map[String, Map[String, String]]) =>
+      (_: Map[String, String]) =>
         new FluctuatedEventHubClient(ssc,
                                      messagesBeforeEmpty,
                                      numBatchesBeforeNewData,

--- a/core/src/test/scala/org/apache/spark/streaming/eventhubs/SharedUtils.scala
+++ b/core/src/test/scala/org/apache/spark/streaming/eventhubs/SharedUtils.scala
@@ -24,7 +24,7 @@ import org.apache.hadoop.fs.{ FileSystem, Path }
 import org.scalatest.{ BeforeAndAfterEach, FunSuite }
 import org.apache.spark.{ SparkConf, SparkContext }
 import org.apache.spark.eventhubscommon.EventHubsConnector
-import org.apache.spark.eventhubscommon.client.EventHubsClientWrapper
+import org.apache.spark.eventhubscommon.client.{ AMQPEventHubsClient, EventHubsClientWrapper }
 import org.apache.spark.eventhubscommon.progress.ProgressTrackerBase
 import org.apache.spark.streaming.{ Duration, Seconds, StreamingContext }
 import org.apache.spark.streaming.eventhubs.checkpoint.{
@@ -93,7 +93,8 @@ private[spark] trait SharedUtils extends FunSuite with BeforeAndAfterEach {
                                               eventHubNamespace,
                                               progressDir,
                                               eventParams,
-                                              EventHubsClientWrapper.apply)
+                                              EventHubsClientWrapper.apply,
+                                              AMQPEventHubsClient.apply)
     newStream
   }
 }


### PR DESCRIPTION
- The AMQPClient interface now matches the EventHubsClientWrapper. 
- Originally the AMQPClient maintained many EventHubsClientWrappers (one for each EventHubs in a namespace). These clients are now managed by the DStream and EventHubsSource. 
- When an AMQPClient is instantiated, it's a single client. 