### PR TITLE
removing client factory parameter from DStream and EventHubsSource

### DIFF
--- a/core/src/main/scala/org/apache/spark/eventhubscommon/RateControlUtils.scala
+++ b/core/src/main/scala/org/apache/spark/eventhubscommon/RateControlUtils.scala
@@ -144,7 +144,7 @@ private[spark] object RateControlUtils extends Logging {
     : Map[EventHubNameAndPartition, (EventHubsOffsetType, Long)] = {
 
     fetchedStartOffsetsInNextBatch.map {
-      case (ehNameAndPartition, (offset, seq)) =>
+      case (ehNameAndPartition, (offset, _)) =>
         val (offsetType, offsetStr) = EventHubsClientWrapper.configureStartOffset(
           offset.toString,
           eventhubsParams.get(ehNameAndPartition.eventHubName) match {

--- a/core/src/main/scala/org/apache/spark/eventhubscommon/RateControlUtils.scala
+++ b/core/src/main/scala/org/apache/spark/eventhubscommon/RateControlUtils.scala
@@ -87,7 +87,7 @@ private[spark] object RateControlUtils extends Logging {
     val r = new mutable.HashMap[EventHubNameAndPartition, (Long, Long)].empty
     for (nameAndPartition <- fetchedHighestOffsetsAndSeqNums.keySet) {
       val name = nameAndPartition.eventHubName
-      val endPoint = eventHubClient(name).endPointOfPartition(nameAndPartition)
+      val endPoint = eventHubClient(name).lastSeqAndOffset(nameAndPartition)
       require(endPoint.isDefined, s"Failed to get ending sequence number for $nameAndPartition")
 
       r += nameAndPartition -> endPoint.get
@@ -110,7 +110,7 @@ private[spark] object RateControlUtils extends Logging {
     val latestEnqueueTimeOfPartitions = new mutable.HashMap[EventHubNameAndPartition, Long].empty
     for (nameAndPartition <- ehNameAndPartitions) {
       val name = nameAndPartition.eventHubName
-      val lastEnqueueTime = eventHubsClient(name).lastEnqueueTimeOfPartitions(nameAndPartition).get
+      val lastEnqueueTime = eventHubsClient(name).lastEnqueuedTime(nameAndPartition).get
 
       latestEnqueueTimeOfPartitions += nameAndPartition -> lastEnqueueTime
     }

--- a/core/src/main/scala/org/apache/spark/eventhubscommon/client/Client.scala
+++ b/core/src/main/scala/org/apache/spark/eventhubscommon/client/Client.scala
@@ -25,8 +25,6 @@ private[spark] trait Client extends Serializable {
 
   private[spark] var client: EventHubClient
 
-  private[spark] def initClient(): Unit
-
   private[spark] def initReceiver(partitionId: String,
                                   offsetType: EventHubsOffsetType,
                                   currentOffset: String): Unit
@@ -37,19 +35,19 @@ private[spark] trait Client extends Serializable {
    * return the start seq number of each partition
    * @return a map from eventhubName-partition to seq
    */
-  def startSeqOfPartition(eventHubNameAndPartition: EventHubNameAndPartition): Option[Long]
+  def beginSeqNo(eventHubNameAndPartition: EventHubNameAndPartition): Option[Long]
 
   /**
    * return the end point of each partition
    * @return a map from eventhubName-partition to (offset, seq)
    */
-  def endPointOfPartition(eventHubNameAndPartition: EventHubNameAndPartition): Option[(Long, Long)]
+  def lastSeqAndOffset(eventHubNameAndPartition: EventHubNameAndPartition): Option[(Long, Long)]
 
   /**
    * return the last enqueueTime of each partition
    * @return a map from eventHubsNamePartition to EnqueueTime
    */
-  def lastEnqueueTimeOfPartitions(eventHubNameAndPartition: EventHubNameAndPartition): Option[Long]
+  def lastEnqueuedTime(eventHubNameAndPartition: EventHubNameAndPartition): Option[Long]
 
   /**
    * close this client

--- a/core/src/main/scala/org/apache/spark/sql/streaming/eventhubs/EventHubsOffset.scala
+++ b/core/src/main/scala/org/apache/spark/sql/streaming/eventhubs/EventHubsOffset.scala
@@ -17,14 +17,13 @@
 
 package org.apache.spark.sql.streaming.eventhubs
 
-import scala.collection.mutable
-import scala.util.control.NonFatal
-
+import org.apache.spark.eventhubscommon.EventHubNameAndPartition
+import org.apache.spark.sql.execution.streaming.Offset
 import org.json4s.NoTypeHints
 import org.json4s.jackson.Serialization
 
-import org.apache.spark.eventhubscommon.EventHubNameAndPartition
-import org.apache.spark.sql.execution.streaming.Offset
+import scala.collection.mutable
+import scala.util.control.NonFatal
 
 // the descriptor of EventHubsBatchRecord to communicate with StreamExecution
 private[streaming] case class EventHubsBatchRecord(
@@ -55,7 +54,7 @@ private object JsonUtils {
           (EventHubNameAndPartition.fromString(ehNameAndPartitionStr), seqNum)
       })
     } catch {
-      case NonFatal(x) =>
+      case NonFatal(_) =>
         throw new IllegalArgumentException(s"failed to parse $jsonStr")
     }
   }

--- a/core/src/main/scala/org/apache/spark/sql/streaming/eventhubs/EventHubsSource.scala
+++ b/core/src/main/scala/org/apache/spark/sql/streaming/eventhubs/EventHubsSource.scala
@@ -246,7 +246,7 @@ private[spark] class EventHubsSource private[eventhubs] (
         val startSeqs = new mutable.HashMap[EventHubNameAndPartition, Long].empty
         for (nameAndPartition <- connectedInstances) {
           val name = nameAndPartition.eventHubName
-          val seqNo = eventHubClient.startSeqOfPartition(nameAndPartition).get
+          val seqNo = eventHubClient.beginSeqNo(nameAndPartition).get
 
           startSeqs += nameAndPartition -> seqNo
         }

--- a/core/src/main/scala/org/apache/spark/sql/streaming/eventhubs/EventHubsSource.scala
+++ b/core/src/main/scala/org/apache/spark/sql/streaming/eventhubs/EventHubsSource.scala
@@ -42,7 +42,6 @@ import scala.collection.mutable
 private[spark] class EventHubsSource private[eventhubs] (
     sqlContext: SQLContext,
     eventHubsParams: Map[String, String],
-    receiverFactory: (Map[String, String]) => Client,
     clientFactory: (Map[String, String]) => Client)
     extends Source
     with EventHubsConnector
@@ -72,7 +71,7 @@ private[spark] class EventHubsSource private[eventhubs] (
 
   private[eventhubs] def eventHubsReceiver = {
     if (_eventHubsReceiver == null) {
-      _eventHubsReceiver = receiverFactory
+      _eventHubsReceiver = clientFactory
     }
     _eventHubsReceiver
   }

--- a/core/src/main/scala/org/apache/spark/sql/streaming/eventhubs/EventHubsSource.scala
+++ b/core/src/main/scala/org/apache/spark/sql/streaming/eventhubs/EventHubsSource.scala
@@ -20,24 +20,24 @@ package org.apache.spark.sql.streaming.eventhubs
 import java.util.concurrent.Executors
 import java.util.concurrent.atomic.AtomicInteger
 
-import scala.concurrent.{ ExecutionContext, Future }
-import scala.util.{ Failure, Success }
+import org.apache.spark.eventhubscommon.client.Client
+import org.apache.spark.eventhubscommon.client.EventHubsOffsetTypes.EventHubsOffsetType
+import org.apache.spark.eventhubscommon.rdd.{ EventHubsRDD, OffsetRange, OffsetStoreParams }
 import org.apache.spark.eventhubscommon.{
   EventHubNameAndPartition,
   EventHubsConnector,
   OffsetRecord,
   RateControlUtils
 }
-import org.apache.spark.eventhubscommon.client.Client
-import org.apache.spark.eventhubscommon.client.EventHubsOffsetTypes.EventHubsOffsetType
-import org.apache.spark.eventhubscommon.rdd.{ EventHubsRDD, OffsetRange, OffsetStoreParams }
 import org.apache.spark.internal.Logging
-import org.apache.spark.sql.{ DataFrame, Row, SQLContext }
 import org.apache.spark.sql.execution.streaming.{ Offset, SerializedOffset, Source }
 import org.apache.spark.sql.streaming.eventhubs.checkpoint.StructuredStreamingProgressTracker
 import org.apache.spark.sql.types._
+import org.apache.spark.sql.{ DataFrame, Row, SQLContext }
 
 import scala.collection.mutable
+import scala.concurrent.{ ExecutionContext, Future }
+import scala.util.{ Failure, Success }
 
 private[spark] class EventHubsSource private[eventhubs] (
     sqlContext: SQLContext,
@@ -157,7 +157,7 @@ private[spark] class EventHubsSource private[eventhubs] (
     Future {
       progressTracker.cleanProgressFile(batchIdToClean)
     }.onComplete {
-      case Success(r) =>
+      case Success(_) =>
         logInfo(s"finished cleanup for batch $batchIdToClean")
       case Failure(exception) =>
         logWarning(

--- a/core/src/main/scala/org/apache/spark/sql/streaming/eventhubs/EventHubsSourceProvider.scala
+++ b/core/src/main/scala/org/apache/spark/sql/streaming/eventhubs/EventHubsSourceProvider.scala
@@ -45,10 +45,7 @@ private[sql] class EventHubsSourceProvider
                             parameters: Map[String, String]): Source = {
     // TODO: use serviceLoader to pass in customized eventhubReceiverCreator and
     // eventhubClientCreator
-    new EventHubsSource(sqlContext,
-                        parameters,
-                        EventHubsClientWrapper.apply,
-                        EventHubsClientWrapper.apply)
+    new EventHubsSource(sqlContext, parameters, EventHubsClientWrapper.apply)
   }
 }
 

--- a/core/src/main/scala/org/apache/spark/streaming/eventhubs/EventHubDirectDStream.scala
+++ b/core/src/main/scala/org/apache/spark/streaming/eventhubs/EventHubDirectDStream.scala
@@ -47,7 +47,6 @@ private[eventhubs] class EventHubDirectDStream private[eventhubs] (
     private[eventhubs] val eventHubNameSpace: String,
     progressDir: String,
     eventhubsParams: Map[String, Map[String, String]],
-    receiverFactory: (Map[String, String]) => Client,
     clientFactory: (Map[String, String]) => Client)
     extends InputDStream[EventData](_ssc)
     with EventHubsConnector
@@ -290,7 +289,7 @@ private[eventhubs] class EventHubDirectDStream private[eventhubs] (
                         streamId,
                         uid = eventHubNameSpace,
                         subDirs = ssc.sparkContext.appName),
-      receiverFactory
+      clientFactory
     )
     reportInputInto(validTime,
                     offsetRanges,
@@ -426,7 +425,7 @@ private[eventhubs] class EventHubDirectDStream private[eventhubs] (
             }.toList,
             t.milliseconds,
             OffsetStoreParams(progressDir, streamId, uid = eventHubNameSpace, subDirs = appName),
-            receiverFactory
+            clientFactory
           )
       }
     }

--- a/core/src/main/scala/org/apache/spark/streaming/eventhubs/EventHubDirectDStream.scala
+++ b/core/src/main/scala/org/apache/spark/streaming/eventhubs/EventHubDirectDStream.scala
@@ -155,7 +155,7 @@ private[eventhubs] class EventHubDirectDStream private[eventhubs] (
       val startSeqs = new mutable.HashMap[EventHubNameAndPartition, Long].empty
       for (nameAndPartition <- eventhubNameAndPartitions) {
         val name = nameAndPartition.eventHubName
-        val seqNo = eventHubClient(name).startSeqOfPartition(nameAndPartition)
+        val seqNo = eventHubClient(name).beginSeqNo(nameAndPartition)
         require(seqNo.isDefined, s"Failed to get starting sequence number for $nameAndPartition")
 
         startSeqs += nameAndPartition -> seqNo.get

--- a/core/src/main/scala/org/apache/spark/streaming/eventhubs/EventHubDirectDStream.scala
+++ b/core/src/main/scala/org/apache/spark/streaming/eventhubs/EventHubDirectDStream.scala
@@ -372,13 +372,6 @@ private[eventhubs] class EventHubDirectDStream private[eventhubs] (
     rdd
   }
 
-  @throws(classOf[IOException])
-  private def readObject(ois: ObjectInputStream): Unit = Utils.tryOrIOException {
-    ois.defaultReadObject()
-    DirectDStreamProgressTracker.registeredConnectors += this
-    initialized = false
-  }
-
   private[eventhubs] class EventHubDirectDStreamCheckpointData(
       eventHubDirectDStream: EventHubDirectDStream)
       extends DStreamCheckpointData(this) {
@@ -444,5 +437,5 @@ private[eventhubs] class EventHubDirectDStream private[eventhubs] (
 
 private[eventhubs] object EventHubDirectDStream {
   val cleanupLock = new Object
-  var lastCleanupTime = -1L
+  private[eventhubs] var lastCleanupTime = -1L
 }

--- a/core/src/main/scala/org/apache/spark/streaming/eventhubs/EventHubsUtils.scala
+++ b/core/src/main/scala/org/apache/spark/streaming/eventhubs/EventHubsUtils.scala
@@ -51,7 +51,6 @@ object EventHubsUtils {
                                               eventHubNamespace,
                                               progressDir,
                                               eventParams,
-                                              EventHubsClientWrapper.apply,
                                               EventHubsClientWrapper.apply)
     newStream
   }
@@ -70,7 +69,6 @@ object EventHubsUtils {
                                               eventHubNamespace,
                                               progressDir,
                                               eventParams,
-                                              EventHubsClientWrapper.apply,
                                               eventHubsClientCreator)
     newStream
   }

--- a/core/src/main/scala/org/apache/spark/streaming/eventhubs/checkpoint/DfsBasedOffsetStore.scala
+++ b/core/src/main/scala/org/apache/spark/streaming/eventhubs/checkpoint/DfsBasedOffsetStore.scala
@@ -162,7 +162,7 @@ class DfsBasedOffsetStore(directory: String, namespace: String, name: String, pa
           offset = backupStream.readUTF()
           readSuccessful = true
         } catch {
-          case e: Exception =>
+          case _: Exception =>
             logError(s"Failed to read offset from backup checkpoint file $backupPath.")
         } finally {
           backupStream.close()

--- a/core/src/test/scala/org/apache/spark/eventhubscommon/client/EventHubsClientWrapperSuite.scala
+++ b/core/src/test/scala/org/apache/spark/eventhubscommon/client/EventHubsClientWrapperSuite.scala
@@ -16,11 +16,9 @@
  */
 package org.apache.spark.eventhubscommon.client
 
-import org.mockito.{ Matchers, Mockito }
 import org.scalatest.{ BeforeAndAfter, FunSuite }
 import org.scalatest.mock.MockitoSugar
 
-import org.apache.spark.eventhubscommon.client.EventHubsOffsetTypes.EventHubsOffsetType
 import org.apache.spark.streaming.eventhubs.checkpoint.OffsetStore
 
 /**

--- a/core/src/test/scala/org/apache/spark/eventhubscommon/utils/SimulatedEventHubs.scala
+++ b/core/src/test/scala/org/apache/spark/eventhubscommon/utils/SimulatedEventHubs.scala
@@ -77,19 +77,13 @@ class SimulatedEventHubsRestClient(eventHubs: SimulatedEventHubs)
     extends Client
     with TestClientSugar {
 
-  override def endPointOfPartition(
+  override def lastSeqAndOffset(
       targetEventHubNameAndPartition: EventHubNameAndPartition): Option[(Long, Long)] = {
     val x = eventHubs.messageStore(targetEventHubNameAndPartition).length.toLong - 1
     Some((x, x))
   }
 
-  /**
-   * return the last enqueueTime of each partition
-   *
-   * @return a map from eventHubsNamePartition to EnqueueTime
-   */
-  override def lastEnqueueTimeOfPartitions(
-      nameAndPartition: EventHubNameAndPartition): Option[Long] = {
+  override def lastEnqueuedTime(nameAndPartition: EventHubNameAndPartition): Option[Long] = {
     Some(
       eventHubs
         .messageStore(nameAndPartition)
@@ -99,12 +93,7 @@ class SimulatedEventHubsRestClient(eventHubs: SimulatedEventHubs)
         .toEpochMilli)
   }
 
-  /**
-   * return the start seq number of each partition
-   *
-   * @return a map from eventhubName-partition to seq
-   */
-  override def startSeqOfPartition(nameAndPartition: EventHubNameAndPartition): Option[Long] = {
+  override def beginSeqNo(nameAndPartition: EventHubNameAndPartition): Option[Long] = {
     Some(-1L)
   }
 }
@@ -139,17 +128,16 @@ class TestEventHubsClient(ehParams: Map[String, String],
     }
   }
 
-  override def endPointOfPartition(
+  override def lastSeqAndOffset(
       nameAndPartition: EventHubNameAndPartition): Option[(Long, Long)] = {
     val (offset, seq, _) = latestRecords(nameAndPartition)
     Some(offset, seq)
   }
 
-  override def lastEnqueueTimeOfPartitions(
-      nameAndPartition: EventHubNameAndPartition): Option[Long] =
+  override def lastEnqueuedTime(nameAndPartition: EventHubNameAndPartition): Option[Long] =
     Some(latestRecords(nameAndPartition)._3)
 
-  override def startSeqOfPartition(nameAndPartition: EventHubNameAndPartition): Option[Long] =
+  override def beginSeqNo(nameAndPartition: EventHubNameAndPartition): Option[Long] =
     Some(-1L)
 }
 
@@ -187,7 +175,7 @@ class FluctuatedEventHubClient(ehParams: Map[String, String],
     }
   }
 
-  override def endPointOfPartition(
+  override def lastSeqAndOffset(
       nameAndPartition: EventHubNameAndPartition): Option[(Long, Long)] = {
     callIndex += 1
     if (callIndex < numBatchesBeforeNewData) {
@@ -197,22 +185,11 @@ class FluctuatedEventHubClient(ehParams: Map[String, String],
     }
   }
 
-  /**
-   * return the last enqueueTime of each partition
-   *
-   * @return a map from eventHubsNamePartition to EnqueueTime
-   */
-  override def lastEnqueueTimeOfPartitions(
-      nameAndPartition: EventHubNameAndPartition): Option[Long] = {
+  override def lastEnqueuedTime(nameAndPartition: EventHubNameAndPartition): Option[Long] = {
     Some(Long.MaxValue)
   }
 
-  /**
-   * return the start seq number of each partition
-   *
-   * @return a map from eventhubName-partition to seq
-   */
-  override def startSeqOfPartition(nameAndPartition: EventHubNameAndPartition): Option[Long] = {
+  override def beginSeqNo(nameAndPartition: EventHubNameAndPartition): Option[Long] = {
     Some(-1L)
   }
 }

--- a/core/src/test/scala/org/apache/spark/eventhubscommon/utils/SimulatedEventHubs.scala
+++ b/core/src/test/scala/org/apache/spark/eventhubscommon/utils/SimulatedEventHubs.scala
@@ -17,12 +17,13 @@
 
 package org.apache.spark.eventhubscommon.utils
 
-import scala.collection.mutable.ListBuffer
 import com.microsoft.azure.eventhubs.EventData
 import org.apache.spark.eventhubscommon.EventHubNameAndPartition
-import org.apache.spark.eventhubscommon.client.{ Client, EventHubsOffsetTypes }
 import org.apache.spark.eventhubscommon.client.EventHubsOffsetTypes.EventHubsOffsetType
+import org.apache.spark.eventhubscommon.client.{ Client, EventHubsOffsetTypes }
 import org.apache.spark.streaming.StreamingContext
+
+import scala.collection.mutable.ListBuffer
 
 class SimulatedEventHubs(eventHubsNamespace: String,
                          initialData: Map[EventHubNameAndPartition, Array[EventData]])
@@ -108,9 +109,9 @@ class SimulatedEventHubsRestClient(eventHubs: SimulatedEventHubs)
   }
 }
 
-class TestRestEventHubClient(ehParams: Map[String, String],
-                             eventHubs: SimulatedEventHubs,
-                             latestRecords: Map[EventHubNameAndPartition, (Long, Long, Long)])
+class TestEventHubsClient(ehParams: Map[String, String],
+                          eventHubs: SimulatedEventHubs,
+                          latestRecords: Map[EventHubNameAndPartition, (Long, Long, Long)])
     extends Client
     with TestClientSugar {
   private var partitionId: Int = _

--- a/core/src/test/scala/org/apache/spark/eventhubscommon/utils/TestClientSugar.scala
+++ b/core/src/test/scala/org/apache/spark/eventhubscommon/utils/TestClientSugar.scala
@@ -31,20 +31,18 @@ trait TestClientSugar extends Client {
 
   override def close(): Unit = {}
 
-  override def endPointOfPartition(
+  override def lastSeqAndOffset(
       eventHubNameAndPartition: EventHubNameAndPartition): Option[(Long, Long)] = Option.empty
-
-  override private[spark] def initClient() = {}
 
   override private[spark] def initReceiver(partitionId: String,
                                            offsetType: EventHubsOffsetType,
                                            currentOffset: String) = {}
 
-  override def lastEnqueueTimeOfPartitions(
-      eventHubNameAndPartition: EventHubNameAndPartition): Option[Long] = Option.empty
+  override def lastEnqueuedTime(eventHubNameAndPartition: EventHubNameAndPartition): Option[Long] =
+    Option.empty
 
   override def receive(expectedEvents: Int): Iterable[EventData] = Iterable[EventData]()
 
-  override def startSeqOfPartition(
-      eventHubNameAndPartition: EventHubNameAndPartition): Option[Long] = Option.empty
+  override def beginSeqNo(eventHubNameAndPartition: EventHubNameAndPartition): Option[Long] =
+    Option.empty
 }

--- a/core/src/test/scala/org/apache/spark/sql/streaming/eventhubs/EventHubsSourceSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/streaming/eventhubs/EventHubsSourceSuite.scala
@@ -79,7 +79,7 @@ class EventHubsSourceSuite extends EventHubsStreamTest with MockitoSugar {
       spark.sqlContext,
       eventHubsParameters,
       (_: Map[String, String]) =>
-        new TestRestEventHubClient(eventHubsParameters, eventHubs, highestOffsetPerPartition)
+        new TestEventHubsClient(eventHubsParameters, eventHubs, highestOffsetPerPartition)
     )
     val offset = eventHubsSource.getOffset.get.asInstanceOf[EventHubsBatchRecord]
     assert(offset.batchId == 0)
@@ -96,7 +96,7 @@ class EventHubsSourceSuite extends EventHubsStreamTest with MockitoSugar {
       spark.sqlContext,
       eventHubsParameters,
       (_: Map[String, String]) =>
-        new TestRestEventHubClient(eventHubsParameters, eventHubs, highestOffsetPerPartition)
+        new TestEventHubsClient(eventHubsParameters, eventHubs, highestOffsetPerPartition)
     )
     val offset = eventHubsSource.getOffset.get.asInstanceOf[EventHubsBatchRecord]
     assert(offset.batchId == 0)
@@ -115,7 +115,7 @@ class EventHubsSourceSuite extends EventHubsStreamTest with MockitoSugar {
       spark.sqlContext,
       ehParams,
       (_: Map[String, String]) =>
-        new TestRestEventHubClient(ehParams, eventHubs, highestOffsetPerPartition)
+        new TestEventHubsClient(ehParams, eventHubs, highestOffsetPerPartition)
     )
     // First batch
     var offset = eventHubsSource.getOffset.get.asInstanceOf[EventHubsBatchRecord]
@@ -143,7 +143,7 @@ class EventHubsSourceSuite extends EventHubsStreamTest with MockitoSugar {
       spark.sqlContext,
       eventHubsParameters,
       (_: Map[String, String]) =>
-        new TestRestEventHubClient(eventHubsParameters, eventHubs, highestOffsetPerPartition)
+        new TestEventHubsClient(eventHubsParameters, eventHubs, highestOffsetPerPartition)
     )
     val offset = eventHubsSource.getOffset.get.asInstanceOf[EventHubsBatchRecord]
     val dataFrame = eventHubsSource.getBatch(None, offset)
@@ -162,7 +162,7 @@ class EventHubsSourceSuite extends EventHubsStreamTest with MockitoSugar {
       spark.sqlContext,
       eventHubsParameters,
       (_: Map[String, String]) =>
-        new TestRestEventHubClient(eventHubsParameters, eventHubs, highestOffsetPerPartition)
+        new TestEventHubsClient(eventHubsParameters, eventHubs, highestOffsetPerPartition)
     )
     val offset = eventHubsSource.getOffset.get.asInstanceOf[EventHubsBatchRecord]
     val dataFrame = eventHubsSource.getBatch(None, offset)
@@ -183,7 +183,7 @@ class EventHubsSourceSuite extends EventHubsStreamTest with MockitoSugar {
       spark.sqlContext,
       eventHubsParameters,
       (_: Map[String, String]) =>
-        new TestRestEventHubClient(eventHubsParameters, eventHubs, highestOffsetPerPartition)
+        new TestEventHubsClient(eventHubsParameters, eventHubs, highestOffsetPerPartition)
     )
     // First batch
     var offset = eventHubsSource.getOffset.get.asInstanceOf[EventHubsBatchRecord]
@@ -219,7 +219,7 @@ class EventHubsSourceSuite extends EventHubsStreamTest with MockitoSugar {
       spark.sqlContext,
       eventHubsParameters,
       (_: Map[String, String]) =>
-        new TestRestEventHubClient(eventHubsParameters, eventHubs, highestOffsetPerPartition)
+        new TestEventHubsClient(eventHubsParameters, eventHubs, highestOffsetPerPartition)
     )
     val offset = eventHubsSource.getOffset.get.asInstanceOf[EventHubsBatchRecord]
     val dataFrame = eventHubsSource.getBatch(None, offset)
@@ -261,7 +261,7 @@ class EventHubsSourceSuite extends EventHubsStreamTest with MockitoSugar {
       spark.sqlContext,
       eventHubsParameters,
       (_: Map[String, String]) =>
-        new TestRestEventHubClient(eventHubsParameters, eventHubs, highestOffsetPerPartition)
+        new TestEventHubsClient(eventHubsParameters, eventHubs, highestOffsetPerPartition)
     )
     val offset = eventHubsSource.getOffset.get.asInstanceOf[EventHubsBatchRecord]
     val dataFrame = eventHubsSource.getBatch(None, offset)
@@ -282,7 +282,7 @@ class EventHubsSourceSuite extends EventHubsStreamTest with MockitoSugar {
       spark.sqlContext,
       eventHubsParameters,
       (_: Map[String, String]) =>
-        new TestRestEventHubClient(eventHubsParameters, eventHubs, highestOffsetPerPartition)
+        new TestEventHubsClient(eventHubsParameters, eventHubs, highestOffsetPerPartition)
     )
     val offset = eventHubsSource.getOffset.get.asInstanceOf[EventHubsBatchRecord]
     val dataFrame = eventHubsSource.getBatch(None, offset)
@@ -308,7 +308,7 @@ class EventHubsSourceSuite extends EventHubsStreamTest with MockitoSugar {
       spark.sqlContext,
       eventHubsParameters,
       (_: Map[String, String]) =>
-        new TestRestEventHubClient(eventHubsParameters, eventHubs, highestOffsetPerPartition)
+        new TestEventHubsClient(eventHubsParameters, eventHubs, highestOffsetPerPartition)
     )
     val offset = eventHubsSource.getOffset.get.asInstanceOf[EventHubsBatchRecord]
     val dataFrame = eventHubsSource.getBatch(None, offset)
@@ -334,7 +334,7 @@ class EventHubsSourceSuite extends EventHubsStreamTest with MockitoSugar {
       spark.sqlContext,
       eventHubsParameters,
       (_: Map[String, String]) =>
-        new TestRestEventHubClient(eventHubsParameters, eventHubs, highestOffsetPerPartition)
+        new TestEventHubsClient(eventHubsParameters, eventHubs, highestOffsetPerPartition)
     )
     val offset = eventHubsSource.getOffset.get.asInstanceOf[EventHubsBatchRecord]
     val dataFrame = eventHubsSource.getBatch(None, offset)

--- a/core/src/test/scala/org/apache/spark/sql/streaming/eventhubs/EventHubsSourceSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/streaming/eventhubs/EventHubsSourceSuite.scala
@@ -78,8 +78,8 @@ class EventHubsSourceSuite extends EventHubsStreamTest with MockitoSugar {
     val eventHubsSource = new EventHubsSource(
       spark.sqlContext,
       eventHubsParameters,
-      (_: Map[String, String]) => new TestEventHubsReceiver(eventHubsParameters, eventHubs),
-      (_: Map[String, String]) => new TestRestEventHubClient(highestOffsetPerPartition)
+      (_: Map[String, String]) =>
+        new TestRestEventHubClient(eventHubsParameters, eventHubs, highestOffsetPerPartition)
     )
     val offset = eventHubsSource.getOffset.get.asInstanceOf[EventHubsBatchRecord]
     assert(offset.batchId == 0)
@@ -95,8 +95,8 @@ class EventHubsSourceSuite extends EventHubsStreamTest with MockitoSugar {
     val eventHubsSource = new EventHubsSource(
       spark.sqlContext,
       eventHubsParameters,
-      (_: Map[String, String]) => new TestEventHubsReceiver(eventHubsParameters, eventHubs),
-      (_: Map[String, String]) => new TestRestEventHubClient(highestOffsetPerPartition)
+      (_: Map[String, String]) =>
+        new TestRestEventHubClient(eventHubsParameters, eventHubs, highestOffsetPerPartition)
     )
     val offset = eventHubsSource.getOffset.get.asInstanceOf[EventHubsBatchRecord]
     assert(offset.batchId == 0)
@@ -114,8 +114,8 @@ class EventHubsSourceSuite extends EventHubsStreamTest with MockitoSugar {
     val eventHubsSource = new EventHubsSource(
       spark.sqlContext,
       ehParams,
-      (_: Map[String, String]) => new TestEventHubsReceiver(ehParams, eventHubs),
-      (_: Map[String, String]) => new TestRestEventHubClient(highestOffsetPerPartition)
+      (_: Map[String, String]) =>
+        new TestRestEventHubClient(ehParams, eventHubs, highestOffsetPerPartition)
     )
     // First batch
     var offset = eventHubsSource.getOffset.get.asInstanceOf[EventHubsBatchRecord]
@@ -142,8 +142,8 @@ class EventHubsSourceSuite extends EventHubsStreamTest with MockitoSugar {
     val eventHubsSource = new EventHubsSource(
       spark.sqlContext,
       eventHubsParameters,
-      (_: Map[String, String]) => new TestEventHubsReceiver(eventHubsParameters, eventHubs),
-      (_: Map[String, String]) => new TestRestEventHubClient(highestOffsetPerPartition)
+      (_: Map[String, String]) =>
+        new TestRestEventHubClient(eventHubsParameters, eventHubs, highestOffsetPerPartition)
     )
     val offset = eventHubsSource.getOffset.get.asInstanceOf[EventHubsBatchRecord]
     val dataFrame = eventHubsSource.getBatch(None, offset)
@@ -161,8 +161,8 @@ class EventHubsSourceSuite extends EventHubsStreamTest with MockitoSugar {
     val eventHubsSource = new EventHubsSource(
       spark.sqlContext,
       eventHubsParameters,
-      (_: Map[String, String]) => new TestEventHubsReceiver(eventHubsParameters, eventHubs),
-      (_: Map[String, String]) => new TestRestEventHubClient(highestOffsetPerPartition)
+      (_: Map[String, String]) =>
+        new TestRestEventHubClient(eventHubsParameters, eventHubs, highestOffsetPerPartition)
     )
     val offset = eventHubsSource.getOffset.get.asInstanceOf[EventHubsBatchRecord]
     val dataFrame = eventHubsSource.getBatch(None, offset)
@@ -182,8 +182,8 @@ class EventHubsSourceSuite extends EventHubsStreamTest with MockitoSugar {
     val eventHubsSource = new EventHubsSource(
       spark.sqlContext,
       eventHubsParameters,
-      (_: Map[String, String]) => new TestEventHubsReceiver(eventHubsParameters, eventHubs),
-      (_: Map[String, String]) => new TestRestEventHubClient(highestOffsetPerPartition)
+      (_: Map[String, String]) =>
+        new TestRestEventHubClient(eventHubsParameters, eventHubs, highestOffsetPerPartition)
     )
     // First batch
     var offset = eventHubsSource.getOffset.get.asInstanceOf[EventHubsBatchRecord]
@@ -218,8 +218,8 @@ class EventHubsSourceSuite extends EventHubsStreamTest with MockitoSugar {
     val eventHubsSource = new EventHubsSource(
       spark.sqlContext,
       eventHubsParameters,
-      (_: Map[String, String]) => new TestEventHubsReceiver(eventHubsParameters, eventHubs),
-      (_: Map[String, String]) => new TestRestEventHubClient(highestOffsetPerPartition)
+      (_: Map[String, String]) =>
+        new TestRestEventHubClient(eventHubsParameters, eventHubs, highestOffsetPerPartition)
     )
     val offset = eventHubsSource.getOffset.get.asInstanceOf[EventHubsBatchRecord]
     val dataFrame = eventHubsSource.getBatch(None, offset)
@@ -260,8 +260,8 @@ class EventHubsSourceSuite extends EventHubsStreamTest with MockitoSugar {
     val eventHubsSource = new EventHubsSource(
       spark.sqlContext,
       eventHubsParameters,
-      (_: Map[String, String]) => new TestEventHubsReceiver(eventHubsParameters, eventHubs),
-      (_: Map[String, String]) => new TestRestEventHubClient(highestOffsetPerPartition)
+      (_: Map[String, String]) =>
+        new TestRestEventHubClient(eventHubsParameters, eventHubs, highestOffsetPerPartition)
     )
     val offset = eventHubsSource.getOffset.get.asInstanceOf[EventHubsBatchRecord]
     val dataFrame = eventHubsSource.getBatch(None, offset)
@@ -281,8 +281,8 @@ class EventHubsSourceSuite extends EventHubsStreamTest with MockitoSugar {
     val eventHubsSource = new EventHubsSource(
       spark.sqlContext,
       eventHubsParameters,
-      (_: Map[String, String]) => new TestEventHubsReceiver(eventHubsParameters, eventHubs),
-      (_: Map[String, String]) => new TestRestEventHubClient(highestOffsetPerPartition)
+      (_: Map[String, String]) =>
+        new TestRestEventHubClient(eventHubsParameters, eventHubs, highestOffsetPerPartition)
     )
     val offset = eventHubsSource.getOffset.get.asInstanceOf[EventHubsBatchRecord]
     val dataFrame = eventHubsSource.getBatch(None, offset)
@@ -307,8 +307,8 @@ class EventHubsSourceSuite extends EventHubsStreamTest with MockitoSugar {
     val eventHubsSource = new EventHubsSource(
       spark.sqlContext,
       eventHubsParameters,
-      (_: Map[String, String]) => new TestEventHubsReceiver(eventHubsParameters, eventHubs),
-      (_: Map[String, String]) => new TestRestEventHubClient(highestOffsetPerPartition)
+      (_: Map[String, String]) =>
+        new TestRestEventHubClient(eventHubsParameters, eventHubs, highestOffsetPerPartition)
     )
     val offset = eventHubsSource.getOffset.get.asInstanceOf[EventHubsBatchRecord]
     val dataFrame = eventHubsSource.getBatch(None, offset)
@@ -333,8 +333,8 @@ class EventHubsSourceSuite extends EventHubsStreamTest with MockitoSugar {
     val eventHubsSource = new EventHubsSource(
       spark.sqlContext,
       eventHubsParameters,
-      (_: Map[String, String]) => new TestEventHubsReceiver(eventHubsParameters, eventHubs),
-      (_: Map[String, String]) => new TestRestEventHubClient(highestOffsetPerPartition)
+      (_: Map[String, String]) =>
+        new TestRestEventHubClient(eventHubsParameters, eventHubs, highestOffsetPerPartition)
     )
     val offset = eventHubsSource.getOffset.get.asInstanceOf[EventHubsBatchRecord]
     val dataFrame = eventHubsSource.getBatch(None, offset)

--- a/core/src/test/scala/org/apache/spark/sql/streaming/eventhubs/EventHubsStreamTest.scala
+++ b/core/src/test/scala/org/apache/spark/sql/streaming/eventhubs/EventHubsStreamTest.scala
@@ -514,7 +514,7 @@ trait EventHubsStreamTest
             eventHubsSource.setEventHubClient(new SimulatedEventHubsRestClient(eventHubs))
             eventHubsSource.setEventHubsReceiver(
               (eventHubsParameters: Map[String, String]) =>
-                new TestEventHubsReceiver(eventHubsParameters, eventHubs)
+                new TestRestEventHubClient(eventHubsParameters, eventHubs, null)
             )
             currentStream.start()
 

--- a/core/src/test/scala/org/apache/spark/sql/streaming/eventhubs/EventHubsStreamTest.scala
+++ b/core/src/test/scala/org/apache/spark/sql/streaming/eventhubs/EventHubsStreamTest.scala
@@ -97,7 +97,7 @@ trait EventHubsStreamTest
   }
 
   /** How long to wait for an active stream to catch up when checking a result. */
-  val streamingTimeout = 60 seconds
+  protected val streamingTimeout = 60 seconds
 
   /** A trait for actions that can be performed while testing a streaming DataFrame. */
   // trait StreamAction
@@ -514,7 +514,7 @@ trait EventHubsStreamTest
             eventHubsSource.setEventHubClient(new SimulatedEventHubsRestClient(eventHubs))
             eventHubsSource.setEventHubsReceiver(
               (eventHubsParameters: Map[String, String]) =>
-                new TestRestEventHubClient(eventHubsParameters, eventHubs, null)
+                new TestEventHubsClient(eventHubsParameters, eventHubs, null)
             )
             currentStream.start()
 
@@ -726,7 +726,7 @@ trait EventHubsStreamTest
   def runStressTest(ds: Dataset[Int],
                     addData: Seq[Int] => StreamAction,
                     iterations: Int = 100): Unit = {
-    runStressTest(ds, Seq.empty, (data, running) => addData(data), iterations)
+    runStressTest(ds, Seq.empty, (data, _) => addData(data), iterations)
   }
 
   /**
@@ -759,7 +759,7 @@ trait EventHubsStreamTest
       actions += addData(data, running)
     }
 
-    (1 to iterations).foreach { i =>
+    (1 to iterations).foreach { _ =>
       val rand = Random.nextDouble()
       if (!running) {
         rand match {

--- a/core/src/test/scala/org/apache/spark/streaming/eventhubs/EventHubDirectDStreamSuite.scala
+++ b/core/src/test/scala/org/apache/spark/streaming/eventhubs/EventHubDirectDStreamSuite.scala
@@ -46,7 +46,6 @@ class EventHubDirectDStreamSuite extends EventHubTestSuiteBase with MockitoSugar
                                               eventhubNamespace,
                                               progressRootPath.toString,
                                               Map("eh1" -> eventhubParameters),
-                                              EventHubsClientWrapper.apply,
                                               EventHubsClientWrapper.apply)
     val eventHubClientMock = mock[Client]
     val ehNameToClient = mutable.HashMap("eh1" -> eventHubClientMock)
@@ -66,7 +65,6 @@ class EventHubDirectDStreamSuite extends EventHubTestSuiteBase with MockitoSugar
                                               eventhubNamespace,
                                               progressRootPath.toString,
                                               Map("eh1" -> eventhubParameters),
-                                              EventHubsClientWrapper.apply,
                                               EventHubsClientWrapper.apply)
     val eventHubClientMock = mock[Client]
     val ehNameToClient = mutable.HashMap("eh1" -> eventHubClientMock)

--- a/core/src/test/scala/org/apache/spark/streaming/eventhubs/EventHubDirectDStreamSuite.scala
+++ b/core/src/test/scala/org/apache/spark/streaming/eventhubs/EventHubDirectDStreamSuite.scala
@@ -17,12 +17,12 @@
 
 package org.apache.spark.streaming.eventhubs
 
-import org.mockito.{ Matchers, Mockito }
-import org.scalatest.mock.MockitoSugar
-import org.apache.spark.eventhubscommon.{ EventHubNameAndPartition, OffsetRecord }
 import org.apache.spark.eventhubscommon.client.{ Client, EventHubsClientWrapper }
+import org.apache.spark.eventhubscommon.{ EventHubNameAndPartition, OffsetRecord }
 import org.apache.spark.rdd.RDD
 import org.apache.spark.streaming.{ Duration, Seconds, Time }
+import org.mockito.{ Matchers, Mockito }
+import org.scalatest.mock.MockitoSugar
 
 import scala.collection.mutable
 
@@ -277,7 +277,7 @@ class EventHubDirectDStreamSuite extends EventHubTestSuiteBase with MockitoSugar
       operation = (inputDStream: EventHubDirectDStream) =>
         inputDStream.map(eventData => eventData.getProperties.get("output").asInstanceOf[Int] + 1),
       expectedOutput,
-      rddOperation = Some((rdd: RDD[Int], t: Time) => {
+      rddOperation = Some((rdd: RDD[Int], _: Time) => {
         Array(rdd.take(1).toSeq)
       })
     )

--- a/core/src/test/scala/org/apache/spark/streaming/eventhubs/EventHubDirectDStreamSuite.scala
+++ b/core/src/test/scala/org/apache/spark/streaming/eventhubs/EventHubDirectDStreamSuite.scala
@@ -51,7 +51,7 @@ class EventHubDirectDStreamSuite extends EventHubTestSuiteBase with MockitoSugar
     val ehNameToClient = mutable.HashMap("eh1" -> eventHubClientMock)
 
     Mockito
-      .when(eventHubClientMock.startSeqOfPartition(Matchers.any[EventHubNameAndPartition]))
+      .when(eventHubClientMock.beginSeqNo(Matchers.any[EventHubNameAndPartition]))
       .thenReturn(None)
     ehDStream.setEventHubClient(ehNameToClient)
     ssc.scheduler.start()
@@ -70,10 +70,10 @@ class EventHubDirectDStreamSuite extends EventHubTestSuiteBase with MockitoSugar
     val ehNameToClient = mutable.HashMap("eh1" -> eventHubClientMock)
 
     Mockito
-      .when(eventHubClientMock.startSeqOfPartition(Matchers.any[EventHubNameAndPartition]))
+      .when(eventHubClientMock.beginSeqNo(Matchers.any[EventHubNameAndPartition]))
       .thenReturn(Some(1L))
     Mockito
-      .when(eventHubClientMock.endPointOfPartition(Matchers.any[EventHubNameAndPartition]))
+      .when(eventHubClientMock.lastSeqAndOffset(Matchers.any[EventHubNameAndPartition]))
       .thenReturn(None)
 
     ehDStream.setEventHubClient(ehNameToClient)

--- a/core/src/test/scala/org/apache/spark/streaming/eventhubs/ProgressTrackingAndCheckpointSuite.scala
+++ b/core/src/test/scala/org/apache/spark/streaming/eventhubs/ProgressTrackingAndCheckpointSuite.scala
@@ -23,7 +23,6 @@ import scala.collection.JavaConverters._
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{ FileSystem, Path }
 import org.apache.spark.eventhubscommon.{ EventHubNameAndPartition, OffsetRecord }
-import org.apache.spark.eventhubscommon.utils.FragileEventHubClient
 import org.apache.spark.streaming._
 import org.apache.spark.streaming.eventhubs.checkpoint.{
   DirectDStreamProgressTracker,

--- a/core/src/test/scala/org/apache/spark/streaming/eventhubs/SharedUtils.scala
+++ b/core/src/test/scala/org/apache/spark/streaming/eventhubs/SharedUtils.scala
@@ -93,7 +93,6 @@ private[spark] trait SharedUtils extends FunSuite with BeforeAndAfterEach {
                                               eventHubNamespace,
                                               progressDir,
                                               eventParams,
-                                              EventHubsClientWrapper.apply,
                                               EventHubsClientWrapper.apply)
     newStream
   }


### PR DESCRIPTION
In this PR:
- Remove extra factory parameter from DStream and EventHubsSource
- Remove Fragile client since we are not using rest client anymore
- consolidated a few test classes 