### PR TITLE
RateControlUtils continued clean-up

### DIFF
--- a/core/src/main/scala/org/apache/spark/eventhubs/common/OffsetRecord.scala
+++ b/core/src/main/scala/org/apache/spark/eventhubs/common/OffsetRecord.scala
@@ -21,4 +21,4 @@ package org.apache.spark.eventhubs.common
  * this class represents the in-memory offset record hold by [[EventHubsConnector]]s
  */
 private[spark] case class OffsetRecord(timestamp: Long,
-                                       offsets: Map[NameAndPartition, (Long, Long)])
+                                       offsetsAndSeqNos: Map[NameAndPartition, (Long, Long)])

--- a/core/src/main/scala/org/apache/spark/eventhubs/common/RateControlUtils.scala
+++ b/core/src/main/scala/org/apache/spark/eventhubs/common/RateControlUtils.scala
@@ -53,10 +53,9 @@ private[spark] object RateControlUtils extends Logging {
 
   private[spark] def composeFromOffsetWithFilteringParams(
       ehParams: Map[String, _],
-      fetchedStartOffsetsInNextBatch: Map[NameAndPartition, (Long, Long)])
+      startOffsetsAndSeqNos: Map[NameAndPartition, (Long, Long)])
     : Map[NameAndPartition, (EventHubsOffsetType, Long)] = {
-
-    fetchedStartOffsetsInNextBatch.map {
+    startOffsetsAndSeqNos.map {
       case (ehNameAndPartition, (offset, _)) =>
         val (offsetType, offsetStr) = configureStartOffset(
           offset.toString,

--- a/core/src/main/scala/org/apache/spark/eventhubs/common/RateControlUtils.scala
+++ b/core/src/main/scala/org/apache/spark/eventhubs/common/RateControlUtils.scala
@@ -63,7 +63,7 @@ private[spark] object RateControlUtils extends Logging {
     }
   }
 
-  private[spark] def fetchLatestOffset(
+  private[spark] def lastOffsetAndSeqNo(
       eventHubClients: Map[String, Client],
       fetchedHighestOffsetsAndSeqNums: Map[NameAndPartition, (Long, Long)])
     : Option[Map[NameAndPartition, (Long, Long)]] = {
@@ -71,7 +71,7 @@ private[spark] object RateControlUtils extends Logging {
     val r = new mutable.HashMap[NameAndPartition, (Long, Long)].empty
     for (nameAndPartition <- fetchedHighestOffsetsAndSeqNums.keySet) {
       val name = nameAndPartition.ehName
-      val endPoint = eventHubClients(name).lastSeqAndOffset(nameAndPartition)
+      val endPoint = eventHubClients(name).lastOffsetAndSeqNo(nameAndPartition)
       require(endPoint.isDefined, s"Failed to get ending sequence number for $nameAndPartition")
 
       r += nameAndPartition -> endPoint.get

--- a/core/src/main/scala/org/apache/spark/eventhubs/common/RateControlUtils.scala
+++ b/core/src/main/scala/org/apache/spark/eventhubs/common/RateControlUtils.scala
@@ -51,6 +51,42 @@ private[spark] object RateControlUtils extends Logging {
     } yield (nameAndPartition, endSeqNo)) toMap
   }
 
+  private[spark] def validateFilteringParams(eventHubsClients: Map[String, Client],
+                                             ehParams: Map[String, _],
+                                             ehNameAndPartitions: List[NameAndPartition]): Unit = {
+
+    // first check if the parameters are valid
+    val latestEnqueueTimeOfPartitions = new mutable.HashMap[NameAndPartition, Long].empty
+    for (nameAndPartition <- ehNameAndPartitions) {
+      val name = nameAndPartition.ehName
+      val lastEnqueueTime = eventHubsClients(name).lastEnqueuedTime(nameAndPartition).get
+
+      latestEnqueueTimeOfPartitions += nameAndPartition -> lastEnqueueTime
+    }
+
+    latestEnqueueTimeOfPartitions.toMap.foreach {
+      case (ehNameAndPartition, latestEnqueueTime) =>
+        val passInEnqueueTime = ehParams.get(ehNameAndPartition.ehName) match {
+          case Some(params) =>
+            params
+              .asInstanceOf[Map[String, String]]
+              .getOrElse("eventhubs.filter.enqueuetime", EventHubsUtils.DefaultEnqueueTime)
+              .toLong
+          case None =>
+            ehParams
+              .asInstanceOf[Map[String, String]]
+              .getOrElse("eventhubs.filter.enqueuetime", EventHubsUtils.DefaultEnqueueTime)
+              .toLong
+        }
+        require(
+          latestEnqueueTime >= passInEnqueueTime,
+          "you cannot pass in an enqueue time which is later than the highest enqueue time in" +
+            s" event hubs, ($ehNameAndPartition, pass-in-enqueuetime $passInEnqueueTime," +
+            s" latest-enqueuetime $latestEnqueueTime)"
+        )
+    }
+  }
+
   private[spark] def composeFromOffsetWithFilteringParams(
       ehParams: Map[String, _],
       startOffsetsAndSeqNos: Map[NameAndPartition, (Long, Long)])

--- a/core/src/main/scala/org/apache/spark/eventhubs/common/RateControlUtils.scala
+++ b/core/src/main/scala/org/apache/spark/eventhubs/common/RateControlUtils.scala
@@ -157,7 +157,7 @@ private[spark] object RateControlUtils extends Logging {
     if (previousOffset != "-1" && previousOffset != null) {
       (EventHubsOffsetTypes.PreviousCheckpoint, previousOffset)
     } else if (ehParams.contains("eventhubs.filter.offset")) {
-      (EventHubsOffsetTypes.InputByteOffset, ehParams("eventhubs.filter.offset"))
+      (EventHubsOffsetTypes.Offset, ehParams("eventhubs.filter.offset"))
     } else if (ehParams.contains("eventhubs.filter.enqueuetime")) {
       (EventHubsOffsetTypes.EnqueueTime, ehParams("eventhubs.filter.enqueuetime"))
     } else {

--- a/core/src/main/scala/org/apache/spark/eventhubs/common/RateControlUtils.scala
+++ b/core/src/main/scala/org/apache/spark/eventhubs/common/RateControlUtils.scala
@@ -63,28 +63,6 @@ private[spark] object RateControlUtils extends Logging {
     }
   }
 
-  private[spark] def lastOffsetAndSeqNo(
-      eventHubClients: Map[String, Client],
-      fetchedHighestOffsetsAndSeqNums: Map[NameAndPartition, (Long, Long)])
-    : Option[Map[NameAndPartition, (Long, Long)]] = {
-
-    val r = new mutable.HashMap[NameAndPartition, (Long, Long)].empty
-    for (nameAndPartition <- fetchedHighestOffsetsAndSeqNums.keySet) {
-      val name = nameAndPartition.ehName
-      val endPoint = eventHubClients(name).lastOffsetAndSeqNo(nameAndPartition)
-      require(endPoint.isDefined, s"Failed to get ending sequence number for $nameAndPartition")
-
-      r += nameAndPartition -> endPoint.get
-    }
-
-    val mergedOffsets = if (fetchedHighestOffsetsAndSeqNums != null) {
-      fetchedHighestOffsetsAndSeqNums ++ r
-    } else {
-      r.toMap
-    }
-    Option(mergedOffsets)
-  }
-
   private[spark] def validateFilteringParams(eventHubsClients: Map[String, Client],
                                              ehParams: Map[String, _],
                                              ehNameAndPartitions: List[NameAndPartition]): Unit = {

--- a/core/src/main/scala/org/apache/spark/eventhubs/common/RateControlUtils.scala
+++ b/core/src/main/scala/org/apache/spark/eventhubs/common/RateControlUtils.scala
@@ -55,19 +55,16 @@ private[spark] object RateControlUtils extends Logging {
       ehParams: Map[String, _],
       startOffsetsAndSeqNos: Map[NameAndPartition, (Long, Long)])
     : Map[NameAndPartition, (EventHubsOffsetType, Long)] = {
-    startOffsetsAndSeqNos.map {
-      case (ehNameAndPartition, (offset, _)) =>
-        val (offsetType, offsetStr) = configureStartOffset(
-          offset.toString,
-          ehParams.get(ehNameAndPartition.ehName) match {
-            case Some(ehConfig) =>
-              ehConfig.asInstanceOf[Map[String, String]]
-            case None =>
-              ehParams.asInstanceOf[Map[String, String]]
-          }
-        )
-        (ehNameAndPartition, (offsetType, offsetStr.toLong))
-    }
+    for {
+      (nameAndPartition, (offset, _)) <- startOffsetsAndSeqNos
+      (offsetType, offsetStr) = configureStartOffset(
+        offset.toString,
+        ehParams.get(nameAndPartition.ehName) match {
+          case Some(x) => x.asInstanceOf[Map[String, String]]
+          case None    => ehParams.asInstanceOf[Map[String, String]]
+        }
+      )
+    } yield (nameAndPartition, (offsetType, offsetStr.toLong))
   }
 
   private[spark] def calculateStartOffset(

--- a/core/src/main/scala/org/apache/spark/eventhubs/common/client/Client.scala
+++ b/core/src/main/scala/org/apache/spark/eventhubs/common/client/Client.scala
@@ -32,25 +32,30 @@ private[spark] trait Client extends Serializable {
   def receive(expectedEvents: Int): Iterable[EventData]
 
   /**
-   * return the start seq number of each partition
+   * Provides the earliest (lowest) sequence number that exists in the EventHubs instance
+   * for the given partition.
+   *
    * @return a map from eventhubName-partition to seq
    */
-  def beginSeqNo(eventHubNameAndPartition: NameAndPartition): Option[Long]
+  def earliestSeqNo(eventHubNameAndPartition: NameAndPartition): Option[Long]
 
   /**
-   * return the end point of each partition
+   * Provides the last (highest) sequence number and offset that exists in the EventHubs
+   * instance for the given partition.
+   *
    * @return a map from eventhubName-partition to (offset, seq)
    */
-  def lastSeqAndOffset(eventHubNameAndPartition: NameAndPartition): Option[(Long, Long)]
+  def lastOffsetAndSeqNo(eventHubNameAndPartition: NameAndPartition): Option[(Long, Long)]
 
   /**
-   * return the last enqueueTime of each partition
+   * Provides the last (highest) enqueue time of an event for a given partition.
+   *
    * @return a map from eventHubsNamePartition to EnqueueTime
    */
   def lastEnqueuedTime(eventHubNameAndPartition: NameAndPartition): Option[Long]
 
   /**
-   * close this client
+   * Closes the EventHubs client.
    */
   def close(): Unit
 }

--- a/core/src/main/scala/org/apache/spark/eventhubs/common/client/Client.scala
+++ b/core/src/main/scala/org/apache/spark/eventhubs/common/client/Client.scala
@@ -45,7 +45,7 @@ private[spark] trait Client extends Serializable {
    *
    * @return a map from eventhubName-partition to (offset, seq)
    */
-  def lastOffsetAndSeqNo(eventHubNameAndPartition: NameAndPartition): Option[(Long, Long)]
+  def lastOffsetAndSeqNo(eventHubNameAndPartition: NameAndPartition): (Long, Long)
 
   /**
    * Provides the last (highest) enqueue time of an event for a given partition.

--- a/core/src/main/scala/org/apache/spark/eventhubs/common/client/EventHubsClientWrapper.scala
+++ b/core/src/main/scala/org/apache/spark/eventhubs/common/client/EventHubsClientWrapper.scala
@@ -89,7 +89,7 @@ private[spark] class EventHubsClientWrapper(private val ehParams: Map[String, St
    *
    * @return a map from eventhubName-partition to seq
    */
-  override def beginSeqNo(nameAndPartition: NameAndPartition): Option[Long] = {
+  override def earliestSeqNo(nameAndPartition: NameAndPartition): Option[Long] = {
     try {
       val runtimeInformation = getRunTimeInfo(nameAndPartition)
       Some(runtimeInformation.getBeginSequenceNumber)
@@ -105,7 +105,7 @@ private[spark] class EventHubsClientWrapper(private val ehParams: Map[String, St
    *
    * @return a map from eventhubName-partition to (offset, seq)
    */
-  override def lastSeqAndOffset(nameAndPartition: NameAndPartition): Option[(Long, Long)] = {
+  override def lastOffsetAndSeqNo(nameAndPartition: NameAndPartition): Option[(Long, Long)] = {
     try {
       val runtimeInfo = getRunTimeInfo(nameAndPartition)
       Some((runtimeInfo.getLastEnqueuedOffset.toLong, runtimeInfo.getLastEnqueuedSequenceNumber))

--- a/core/src/main/scala/org/apache/spark/eventhubs/common/client/EventHubsClientWrapper.scala
+++ b/core/src/main/scala/org/apache/spark/eventhubs/common/client/EventHubsClientWrapper.scala
@@ -105,10 +105,10 @@ private[spark] class EventHubsClientWrapper(private val ehParams: Map[String, St
    *
    * @return a map from eventhubName-partition to (offset, seq)
    */
-  override def lastOffsetAndSeqNo(nameAndPartition: NameAndPartition): Option[(Long, Long)] = {
+  override def lastOffsetAndSeqNo(nameAndPartition: NameAndPartition): (Long, Long) = {
     try {
       val runtimeInfo = getRunTimeInfo(nameAndPartition)
-      Some((runtimeInfo.getLastEnqueuedOffset.toLong, runtimeInfo.getLastEnqueuedSequenceNumber))
+      (runtimeInfo.getLastEnqueuedOffset.toLong, runtimeInfo.getLastEnqueuedSequenceNumber)
     } catch {
       case e: Exception =>
         e.printStackTrace()

--- a/core/src/main/scala/org/apache/spark/eventhubs/common/client/EventHubsClientWrapper.scala
+++ b/core/src/main/scala/org/apache/spark/eventhubs/common/client/EventHubsClientWrapper.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.eventhubs.common.client
 
-import java.time.Instant
+import java.time.{ Duration, Instant }
 
 import scala.collection.JavaConverters._
 import EventHubsOffsetTypes.EventHubsOffsetType
@@ -62,6 +62,7 @@ private[spark] class EventHubsClientWrapper(private val ehParams: Map[String, St
       case _ =>
         client.createReceiverSync(consumerGroup, partitionId, currentOffset)
     }
+    partitionReceiver.setReceiveTimeout(Duration.ofSeconds(5))
   }
 
   def receive(expectedEventNum: Int): Iterable[EventData] = {

--- a/core/src/main/scala/org/apache/spark/eventhubs/common/client/EventHubsOffsetTypes.scala
+++ b/core/src/main/scala/org/apache/spark/eventhubs/common/client/EventHubsOffsetTypes.scala
@@ -20,5 +20,5 @@ package org.apache.spark.eventhubs.common.client
 private[spark] object EventHubsOffsetTypes extends Enumeration {
   type EventHubsOffsetType = Value
 
-  val None, PreviousCheckpoint, InputByteOffset, EnqueueTime = Value
+  val None, PreviousCheckpoint, Offset, EnqueueTime = Value
 }

--- a/core/src/main/scala/org/apache/spark/eventhubs/common/rdd/EventHubsRDD.scala
+++ b/core/src/main/scala/org/apache/spark/eventhubs/common/rdd/EventHubsRDD.scala
@@ -43,7 +43,7 @@ private[spark] class EventHubsRDD(sc: SparkContext,
                                   ehParams: Map[String, Map[String, String]],
                                   val offsetRanges: List[OffsetRange],
                                   batchTime: Long,
-                                  offsetParams: OffsetStoreParams,
+                                  offsetParams: ProgressTrackerParams,
                                   receiverFactory: (Map[String, String]) => Client)
     extends RDD[EventData](sc, Nil) {
 

--- a/core/src/main/scala/org/apache/spark/eventhubs/common/rdd/OffsetRange.scala
+++ b/core/src/main/scala/org/apache/spark/eventhubs/common/rdd/OffsetRange.scala
@@ -20,6 +20,8 @@ package org.apache.spark.eventhubs.common.rdd
 import org.apache.spark.eventhubs.common.NameAndPartition
 import org.apache.spark.eventhubs.common.client.EventHubsOffsetTypes.EventHubsOffsetType
 
+import language.implicitConversions
+
 private[spark] case class OffsetRange(nameAndPartition: NameAndPartition,
                                       fromOffset: Long,
                                       fromSeq: Long,
@@ -27,4 +29,14 @@ private[spark] case class OffsetRange(nameAndPartition: NameAndPartition,
                                       offsetType: EventHubsOffsetType) {
 
   private[spark] def toTuple = (nameAndPartition, fromOffset, fromSeq, untilSeq, offsetType)
+}
+
+private[spark] object OffsetRange {
+  type OffsetRangeTuple = (NameAndPartition, Long, Long, Long, EventHubsOffsetType)
+
+  implicit def tupleToOffsetRange(tuple: OffsetRangeTuple): OffsetRange =
+    OffsetRange(tuple._1, tuple._2, tuple._3, tuple._4, tuple._5)
+
+  implicit def tupleListToOffsetRangeList(list: List[OffsetRangeTuple]): List[OffsetRange] =
+    for { tuple <- list } yield tupleToOffsetRange(tuple)
 }

--- a/core/src/main/scala/org/apache/spark/eventhubs/common/rdd/ProgressTrackerParams.scala
+++ b/core/src/main/scala/org/apache/spark/eventhubs/common/rdd/ProgressTrackerParams.scala
@@ -17,8 +17,8 @@
 
 package org.apache.spark.eventhubs.common.rdd
 
-// a helper object to avoid serializing OffsetStore instances
-private[spark] case class OffsetStoreParams(checkpointDir: String,
-                                            streamId: Int,
-                                            uid: String,
-                                            subDirs: String*)
+// This class contains the information the RDD needs to write temp progress files.
+private[spark] case class ProgressTrackerParams(checkpointDir: String,
+                                                streamId: Int,
+                                                uid: String,
+                                                subDirs: String*)

--- a/core/src/main/scala/org/apache/spark/sql/streaming/eventhubs/EventHubsSource.scala
+++ b/core/src/main/scala/org/apache/spark/sql/streaming/eventhubs/EventHubsSource.scala
@@ -22,7 +22,7 @@ import java.util.concurrent.atomic.AtomicInteger
 
 import org.apache.spark.eventhubs.common.client.Client
 import org.apache.spark.eventhubs.common.client.EventHubsOffsetTypes.EventHubsOffsetType
-import org.apache.spark.eventhubs.common.rdd.{ EventHubsRDD, OffsetRange, OffsetStoreParams }
+import org.apache.spark.eventhubs.common.rdd.{ EventHubsRDD, OffsetRange, ProgressTrackerParams }
 import org.apache.spark.eventhubs.common.{
   NameAndPartition,
   EventHubsConnector,
@@ -282,11 +282,11 @@ private[spark] class EventHubsSource private[eventhubs] (
       Map(eventHubsParams("eventhubs.name") -> eventHubsParams),
       offsetRanges,
       committedOffsetsAndSeqNums.batchId + 1,
-      OffsetStoreParams(eventHubsParams("eventhubs.progressTrackingDir"),
-                        streamId,
-                        uid = uid,
-                        subDirs = sqlContext.sparkContext.appName,
-                        uid),
+      ProgressTrackerParams(eventHubsParams("eventhubs.progressTrackingDir"),
+                            streamId,
+                            uid = uid,
+                            subDirs = sqlContext.sparkContext.appName,
+                            uid),
       receiverFactory
     )
   }

--- a/core/src/main/scala/org/apache/spark/sql/streaming/eventhubs/EventHubsSource.scala
+++ b/core/src/main/scala/org/apache/spark/sql/streaming/eventhubs/EventHubsSource.scala
@@ -242,6 +242,9 @@ private[spark] class EventHubsSource private[eventhubs] (
           case (ehNameAndPartition, (offset, _)) =>
             (ehNameAndPartition, (offset, startSeqs(ehNameAndPartition)))
         })
+        RateControlUtils.validateFilteringParams(Map(eventHubsName -> ehClient),
+                                                 eventHubsParams,
+                                                 ehNameAndPartitions)
         RateControlUtils.composeFromOffsetWithFilteringParams(eventHubsParams,
                                                               committedOffsetsAndSeqNums.offsets)
       } else {

--- a/core/src/main/scala/org/apache/spark/sql/streaming/eventhubs/EventHubsSource.scala
+++ b/core/src/main/scala/org/apache/spark/sql/streaming/eventhubs/EventHubsSource.scala
@@ -177,7 +177,7 @@ private[spark] class EventHubsSource private[eventhubs] (
       firstBatch = false
     }
     val targetOffsets = RateControlUtils.clamp(committedOffsetsAndSeqNums.offsets,
-                                               highestOffsetsOpt.get,
+                                               highestOffsetsOpt.get.toList,
                                                eventHubsParams)
     Some(
       EventHubsBatchRecord(

--- a/core/src/main/scala/org/apache/spark/sql/streaming/eventhubs/EventHubsSource.scala
+++ b/core/src/main/scala/org/apache/spark/sql/streaming/eventhubs/EventHubsSource.scala
@@ -117,7 +117,7 @@ private[spark] class EventHubsSource private[eventhubs] (
 
   private[spark] def composeHighestOffset(
       retryIfFail: Boolean): Option[Map[NameAndPartition, (Long, Long)]] = {
-    RateControlUtils.fetchLatestOffset(
+    RateControlUtils.lastOffsetAndSeqNo(
       Map(eventHubsName -> ehClient),
       if (fetchedHighestOffsetsAndSeqNums == null) {
         committedOffsetsAndSeqNums.offsets
@@ -241,7 +241,7 @@ private[spark] class EventHubsSource private[eventhubs] (
         val startSeqs = new mutable.HashMap[NameAndPartition, Long].empty
         for (nameAndPartition <- namesAndPartitions) {
           val name = nameAndPartition.ehName
-          val seqNo = ehClient.beginSeqNo(nameAndPartition).get
+          val seqNo = ehClient.earliestSeqNo(nameAndPartition).get
 
           startSeqs += nameAndPartition -> seqNo
         }

--- a/core/src/main/scala/org/apache/spark/streaming/eventhubs/EventHubDirectDStream.scala
+++ b/core/src/main/scala/org/apache/spark/streaming/eventhubs/EventHubDirectDStream.scala
@@ -29,7 +29,7 @@ import org.apache.spark.eventhubs.common.{
 }
 import org.apache.spark.eventhubs.common.client.Client
 import org.apache.spark.eventhubs.common.client.EventHubsOffsetTypes.EventHubsOffsetType
-import org.apache.spark.eventhubs.common.rdd.{ EventHubsRDD, OffsetRange, OffsetStoreParams }
+import org.apache.spark.eventhubs.common.rdd.{ EventHubsRDD, OffsetRange, ProgressTrackerParams }
 import org.apache.spark.internal.Logging
 import org.apache.spark.rdd.RDD
 import org.apache.spark.streaming.{ StreamingContext, Time }
@@ -260,10 +260,10 @@ private[spark] class EventHubDirectDStream private[spark] (
       ehParams,
       offsetRanges,
       validTime.milliseconds,
-      OffsetStoreParams(progressDir,
-                        streamId,
-                        uid = ehNamespace,
-                        subDirs = ssc.sparkContext.appName),
+      ProgressTrackerParams(progressDir,
+                            streamId,
+                            uid = ehNamespace,
+                            subDirs = ssc.sparkContext.appName),
       clientFactory
     )
     reportInputInto(validTime,
@@ -384,7 +384,7 @@ private[spark] class EventHubDirectDStream private[spark] (
                 OffsetRange(ehNameAndPar, fromOffset, fromSeq, untilSeq, offsetType)
             }.toList,
             t.milliseconds,
-            OffsetStoreParams(progressDir, streamId, uid = ehNamespace, subDirs = appName),
+            ProgressTrackerParams(progressDir, streamId, uid = ehNamespace, subDirs = appName),
             clientFactory
           )
       }

--- a/core/src/main/scala/org/apache/spark/streaming/eventhubs/EventHubDirectDStream.scala
+++ b/core/src/main/scala/org/apache/spark/streaming/eventhubs/EventHubDirectDStream.scala
@@ -207,6 +207,7 @@ private[spark] class EventHubDirectDStream private[spark] (
     val filteringOffsetAndType = {
       if (shouldCareEnqueueTimeOrOffset) {
         // first check if the parameters are valid
+        RateControlUtils.validateFilteringParams(ehClients.toMap, ehParams, namesAndPartitions)
         RateControlUtils.composeFromOffsetWithFilteringParams(
           ehParams,
           currentOffsetsAndSeqNos.offsetsAndSeqNos)

--- a/core/src/main/scala/org/apache/spark/streaming/eventhubs/EventHubDirectDStream.scala
+++ b/core/src/main/scala/org/apache/spark/streaming/eventhubs/EventHubDirectDStream.scala
@@ -189,7 +189,7 @@ private[spark] class EventHubDirectDStream private[spark] (
   private def clamp(
       highestEndpoints: Map[NameAndPartition, (Long, Long)]): Map[NameAndPartition, Long] = {
     RateControlUtils.clamp(currentOffsetsAndSeqNos.offsets,
-                           highestOffsetsAndSeqNos.offsets,
+                           highestOffsetsAndSeqNos.offsets.toList,
                            ehParams)
   }
 

--- a/core/src/main/scala/org/apache/spark/streaming/eventhubs/checkpoint/ProgressTrackingListener.scala
+++ b/core/src/main/scala/org/apache/spark/streaming/eventhubs/checkpoint/ProgressTrackingListener.scala
@@ -38,7 +38,7 @@ private[eventhubs] class ProgressTrackingListener private (ssc: StreamingContext
       if (batchCompleted.batchInfo.outputOperationInfos.forall(_._2.failureReason.isEmpty)) {
         val progressTracker =
           DirectDStreamProgressTracker.getInstance.asInstanceOf[DirectDStreamProgressTracker]
-        // build current offsets
+        // build current offsetsAndSeqNos
         val allEventDStreams = DirectDStreamProgressTracker.registeredConnectors
         // merge with the temp directory
         val startTime = System.currentTimeMillis()
@@ -49,7 +49,7 @@ private[eventhubs] class ProgressTrackingListener private (ssc: StreamingContext
           val contentToCommit = allEventDStreams
             .map {
               case dstream: EventHubDirectDStream =>
-                (dstream.ehNamespace, dstream.currentOffsetsAndSeqNos.offsets)
+                (dstream.ehNamespace, dstream.currentOffsetsAndSeqNos.offsetsAndSeqNos)
             }
             .toMap
             .map {

--- a/core/src/main/scala/org/apache/spark/streaming/eventhubs/checkpoint/ProgressTrackingListener.scala
+++ b/core/src/main/scala/org/apache/spark/streaming/eventhubs/checkpoint/ProgressTrackingListener.scala
@@ -49,7 +49,7 @@ private[eventhubs] class ProgressTrackingListener private (ssc: StreamingContext
           val contentToCommit = allEventDStreams
             .map {
               case dstream: EventHubDirectDStream =>
-                (dstream.ehNamespace, dstream.currentOffsetsAndSeqNums.offsets)
+                (dstream.ehNamespace, dstream.currentOffsetsAndSeqNos.offsets)
             }
             .toMap
             .map {

--- a/core/src/test/scala/org/apache/spark/eventhubs/common/utils/TestClients.scala
+++ b/core/src/test/scala/org/apache/spark/eventhubs/common/utils/TestClients.scala
@@ -33,9 +33,9 @@ class SimulatedEventHubsRestClient(eventHubs: SimulatedEventHubs)
     with TestClientSugar {
 
   override def lastOffsetAndSeqNo(
-      targetEventHubNameAndPartition: NameAndPartition): Option[(Long, Long)] = {
+      targetEventHubNameAndPartition: NameAndPartition): (Long, Long) = {
     val x = eventHubs.messageStore(targetEventHubNameAndPartition).length.toLong - 1
-    Some((x, x))
+    (x, x)
   }
 
   override def lastEnqueuedTime(nameAndPartition: NameAndPartition): Option[Long] = {
@@ -67,9 +67,9 @@ class TestEventHubsClient(ehParams: Map[String, String],
     }
   }
 
-  override def lastOffsetAndSeqNo(nameAndPartition: NameAndPartition): Option[(Long, Long)] = {
+  override def lastOffsetAndSeqNo(nameAndPartition: NameAndPartition): (Long, Long) = {
     val (offset, seq, _) = latestRecords(nameAndPartition)
-    Some(offset, seq)
+    (offset, seq)
   }
 
   override def lastEnqueuedTime(nameAndPartition: NameAndPartition): Option[Long] =
@@ -99,12 +99,12 @@ class FluctuatedEventHubClient(ehParams: Map[String, String],
     }
   }
 
-  override def lastOffsetAndSeqNo(nameAndPartition: NameAndPartition): Option[(Long, Long)] = {
+  override def lastOffsetAndSeqNo(nameAndPartition: NameAndPartition): (Long, Long) = {
     callIndex += 1
     if (callIndex < numBatchesBeforeNewData) {
-      Some(messagesBeforeEmpty - 1, messagesBeforeEmpty - 1)
+      (messagesBeforeEmpty - 1, messagesBeforeEmpty - 1)
     } else {
-      Some(latestRecords(nameAndPartition))
+      (latestRecords(nameAndPartition))
     }
   }
 
@@ -122,9 +122,8 @@ sealed trait TestClientSugar extends Client {
 
   override def close(): Unit = {}
 
-  override def lastOffsetAndSeqNo(
-      eventHubNameAndPartition: NameAndPartition): Option[(Long, Long)] =
-    Option.empty
+  override def lastOffsetAndSeqNo(eventHubNameAndPartition: NameAndPartition): (Long, Long) =
+    null
 
   override def initReceiver(partitionId: String,
                             offsetType: EventHubsOffsetType,

--- a/core/src/test/scala/org/apache/spark/eventhubs/common/utils/TestClients.scala
+++ b/core/src/test/scala/org/apache/spark/eventhubs/common/utils/TestClients.scala
@@ -32,7 +32,7 @@ class SimulatedEventHubsRestClient(eventHubs: SimulatedEventHubs)
     extends Client
     with TestClientSugar {
 
-  override def lastSeqAndOffset(
+  override def lastOffsetAndSeqNo(
       targetEventHubNameAndPartition: NameAndPartition): Option[(Long, Long)] = {
     val x = eventHubs.messageStore(targetEventHubNameAndPartition).length.toLong - 1
     Some((x, x))
@@ -67,7 +67,7 @@ class TestEventHubsClient(ehParams: Map[String, String],
     }
   }
 
-  override def lastSeqAndOffset(nameAndPartition: NameAndPartition): Option[(Long, Long)] = {
+  override def lastOffsetAndSeqNo(nameAndPartition: NameAndPartition): Option[(Long, Long)] = {
     val (offset, seq, _) = latestRecords(nameAndPartition)
     Some(offset, seq)
   }
@@ -99,7 +99,7 @@ class FluctuatedEventHubClient(ehParams: Map[String, String],
     }
   }
 
-  override def lastSeqAndOffset(nameAndPartition: NameAndPartition): Option[(Long, Long)] = {
+  override def lastOffsetAndSeqNo(nameAndPartition: NameAndPartition): Option[(Long, Long)] = {
     callIndex += 1
     if (callIndex < numBatchesBeforeNewData) {
       Some(messagesBeforeEmpty - 1, messagesBeforeEmpty - 1)
@@ -122,7 +122,8 @@ sealed trait TestClientSugar extends Client {
 
   override def close(): Unit = {}
 
-  override def lastSeqAndOffset(eventHubNameAndPartition: NameAndPartition): Option[(Long, Long)] =
+  override def lastOffsetAndSeqNo(
+      eventHubNameAndPartition: NameAndPartition): Option[(Long, Long)] =
     Option.empty
 
   override def initReceiver(partitionId: String,
@@ -138,6 +139,6 @@ sealed trait TestClientSugar extends Client {
 
   override def receive(expectedEvents: Int): Iterable[EventData] = Iterable[EventData]()
 
-  override def beginSeqNo(eventHubNameAndPartition: NameAndPartition): Option[Long] =
+  override def earliestSeqNo(eventHubNameAndPartition: NameAndPartition): Option[Long] =
     Some(-1L)
 }

--- a/core/src/test/scala/org/apache/spark/sql/streaming/eventhubs/EventHubsSourceSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/streaming/eventhubs/EventHubsSourceSuite.scala
@@ -66,7 +66,7 @@ class EventHubsSourceSuite extends EventHubsStreamTest with MockitoSugar {
       yield bodyId.toString -> Seq("propertyV" -> null, "property" -> null)
   }
 
-  test("Verify expected offsets are correct when rate is less than the available data") {
+  test("Verify expected offsetsAndSeqNos are correct when rate is less than the available data") {
     val eventHubsParameters = buildEventHubsParameters("ns1", "eh1", 2, 2)
     val eventPayloadsAndProperties = generateIntKeyedData(6).map {
       case (body, properties) =>
@@ -86,7 +86,7 @@ class EventHubsSourceSuite extends EventHubsStreamTest with MockitoSugar {
     offset.targetSeqNums.values.foreach(x => assert(x == 1))
   }
 
-  test("Verify expected offsets are correct when rate is more than the available data") {
+  test("Verify expected offsetsAndSeqNos are correct when rate is more than the available data") {
     val eventHubsParameters = buildEventHubsParameters("ns1", "eh1", 2, 10)
     val eventPayloadsAndProperties = generateIntKeyedData(6)
     val eventHubs =
@@ -104,7 +104,7 @@ class EventHubsSourceSuite extends EventHubsStreamTest with MockitoSugar {
   }
 
   test(
-    "Verify expected offsets are correct when in subsequent fetch when rate is less than the available data") {
+    "Verify expected offsetsAndSeqNos are correct when in subsequent fetch when rate is less than the available data") {
     val ehParams = buildEventHubsParameters("ns1", "eh1", 2, 3)
     val eventPayloadsAndProperties = generateIntKeyedData(10)
     val eventHubs =

--- a/core/src/test/scala/org/apache/spark/sql/streaming/eventhubs/EventHubsSourceSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/streaming/eventhubs/EventHubsSourceSuite.scala
@@ -809,17 +809,4 @@ class EventHubsSourceSuite extends EventHubsStreamTest with MockitoSugar {
       CheckAnswer(true, false, 7, 8, 9, 10, 11, 12, 13, 14, 15)
     )
   }
-
-  test("Users cannot submit enqueueTime which is later than the latest in the queue") {
-    val eventHubsParameters =
-      buildEventHubsParameters("ns1", "eh1", 2, 3, enqueueTime = Some(Long.MaxValue))
-    val eventPayloadsAndProperties = generateIntKeyedData(15)
-    EventHubsTestUtilities.simulateEventHubs(eventHubsParameters, eventPayloadsAndProperties)
-    val sourceQuery = generateInputQuery(eventHubsParameters, spark)
-    val manualClock = new StreamManualClock
-    testStream(sourceQuery)(
-      StartStream(trigger = ProcessingTime(10), triggerClock = manualClock),
-      ExpectFailure[IllegalArgumentException]()
-    )
-  }
 }

--- a/core/src/test/scala/org/apache/spark/streaming/eventhubs/CheckpointAndProgressTrackerTestSuiteBase.scala
+++ b/core/src/test/scala/org/apache/spark/streaming/eventhubs/CheckpointAndProgressTrackerTestSuiteBase.scala
@@ -137,8 +137,8 @@ trait CheckpointAndProgressTrackerTestSuiteBase extends EventHubTestSuiteBase { 
     validateTempFileCleanup(
       expectedOutputBeforeRestart.length - 1,
       expectedOutputBeforeRestart.length,
-      expectedStartingOffsetsAndSeqs1.values.flatMap(_.offsets).size +
-        expectedStartingOffsetsAndSeqs2.values.flatMap(_.offsets).size
+      expectedStartingOffsetsAndSeqs1.values.flatMap(_.offsetsAndSeqNos).size +
+        expectedStartingOffsetsAndSeqs2.values.flatMap(_.offsetsAndSeqNos).size
     )
 
     val currentCheckpointDir = ssc.checkpointDir
@@ -166,8 +166,8 @@ trait CheckpointAndProgressTrackerTestSuiteBase extends EventHubTestSuiteBase { 
     validateTempFileCleanup(
       expectedOutputBeforeRestart.length + expectedOutputAfterRestart.length - 2,
       expectedOutputBeforeRestart.length + expectedOutputAfterRestart.length - 1,
-      expectedStartingOffsetsAndSeqs1.values.flatMap(_.offsets).size +
-        expectedStartingOffsetsAndSeqs2.values.flatMap(_.offsets).size
+      expectedStartingOffsetsAndSeqs1.values.flatMap(_.offsetsAndSeqNos).size +
+        expectedStartingOffsetsAndSeqs2.values.flatMap(_.offsetsAndSeqNos).size
     )
   }
 
@@ -192,7 +192,7 @@ trait CheckpointAndProgressTrackerTestSuiteBase extends EventHubTestSuiteBase { 
                                 expectedOutputBeforeRestart.length)
     validateTempFileCleanup(expectedOutputBeforeRestart.length - 1,
                             expectedOutputBeforeRestart.length,
-                            expectedOffsetsAndSeqs.offsets.size)
+                            expectedOffsetsAndSeqs.offsetsAndSeqNos.size)
 
     val currentCheckpointDir = ssc.checkpointDir
     // simulate down
@@ -245,7 +245,7 @@ trait CheckpointAndProgressTrackerTestSuiteBase extends EventHubTestSuiteBase { 
     validateTempFileCleanup(
       expectedOutputBeforeRestart.length + expectedOutputAfterRestart.length - 2,
       expectedOutputBeforeRestart.length + expectedOutputAfterRestart.length - 1,
-      expectedOffsetsAndSeqs.offsets.size
+      expectedOffsetsAndSeqs.offsetsAndSeqNos.size
     )
   }
 }

--- a/core/src/test/scala/org/apache/spark/streaming/eventhubs/EventHubDirectDStreamSuite.scala
+++ b/core/src/test/scala/org/apache/spark/streaming/eventhubs/EventHubDirectDStreamSuite.scala
@@ -50,7 +50,7 @@ class EventHubDirectDStreamSuite extends EventHubTestSuiteBase with MockitoSugar
     val ehNameToClient = mutable.HashMap("eh1" -> eventHubClientMock)
 
     Mockito
-      .when(eventHubClientMock.beginSeqNo(Matchers.any[NameAndPartition]))
+      .when(eventHubClientMock.earliestSeqNo(Matchers.any[NameAndPartition]))
       .thenReturn(None)
     ehDStream.ehClients = ehNameToClient
     ssc.scheduler.start()
@@ -68,10 +68,10 @@ class EventHubDirectDStreamSuite extends EventHubTestSuiteBase with MockitoSugar
     val ehNameToClient = mutable.HashMap("eh1" -> eventHubClientMock)
 
     Mockito
-      .when(eventHubClientMock.beginSeqNo(Matchers.any[NameAndPartition]))
+      .when(eventHubClientMock.earliestSeqNo(Matchers.any[NameAndPartition]))
       .thenReturn(Some(1L))
     Mockito
-      .when(eventHubClientMock.lastSeqAndOffset(Matchers.any[NameAndPartition]))
+      .when(eventHubClientMock.lastOffsetAndSeqNo(Matchers.any[NameAndPartition]))
       .thenReturn(None)
     ehDStream.ehClients = ehNameToClient
     ssc.scheduler.start()

--- a/core/src/test/scala/org/apache/spark/streaming/eventhubs/EventHubDirectDStreamSuite.scala
+++ b/core/src/test/scala/org/apache/spark/streaming/eventhubs/EventHubDirectDStreamSuite.scala
@@ -322,33 +322,4 @@ class EventHubDirectDStreamSuite extends EventHubTestSuiteBase with MockitoSugar
       4000L
     )
   }
-
-  test("pass-in enqueuetime is not allowed to be later than the highest enqueuetime") {
-    val input = Seq(Seq(1, 2, 3, 4, 5, 6), Seq(4, 5, 6, 7, 8, 9), Seq(7, 8, 9, 1, 2, 3))
-    val expectedOutput = Seq(Seq(5, 6, 8, 9, 2, 3), Seq(7, 10, 4), Seq())
-    intercept[IllegalArgumentException] {
-      testUnaryOperation(
-        input,
-        eventhubsParams = Map[String, Map[String, String]](
-          "eh1" -> Map(
-            "eventhubs.partition.count" -> "3",
-            "eventhubs.namespace" -> "eventhubs",
-            "eventhubs.maxRate" -> "2",
-            "eventhubs.name" -> "eh1",
-            "eventhubs.filter.enqueuetime" -> "10000"
-          )
-        ),
-        expectedOffsetsAndSeqs = Map(
-          eventhubNamespace ->
-            OffsetRecord(2000L,
-                         Map(NameAndPartition("eh1", 0) -> (5L, 5L),
-                             NameAndPartition("eh1", 1) -> (5L, 5L),
-                             NameAndPartition("eh1", 2) -> (5L, 5L)))),
-        operation = (inputDStream: EventHubDirectDStream) =>
-          inputDStream.map(eventData =>
-            eventData.getProperties.get("output").asInstanceOf[Int] + 1),
-        expectedOutput
-      )
-    }
-  }
 }

--- a/core/src/test/scala/org/apache/spark/streaming/eventhubs/EventHubTestSuiteBase.scala
+++ b/core/src/test/scala/org/apache/spark/streaming/eventhubs/EventHubTestSuiteBase.scala
@@ -225,7 +225,7 @@ private[eventhubs] trait EventHubTestSuiteBase extends TestSuiteBase {
       .filter(_.isInstanceOf[EventHubDirectDStream])
       .map(_.asInstanceOf[EventHubDirectDStream])
       .filter(_.ehNamespace == namespace)
-      .map(eventHubStream => (eventHubStream.ehNamespace, eventHubStream.currentOffsetsAndSeqNums))
+      .map(eventHubStream => (eventHubStream.ehNamespace, eventHubStream.currentOffsetsAndSeqNos))
       .toMap
     assert(expectedOffsetsAndSeqs === producedOffsetsAndSeqs)
   }

--- a/core/src/test/scala/org/apache/spark/streaming/eventhubs/ProgressTrackingAndCheckpointSuite.scala
+++ b/core/src/test/scala/org/apache/spark/streaming/eventhubs/ProgressTrackingAndCheckpointSuite.scala
@@ -84,7 +84,7 @@ class ProgressTrackingAndCheckpointSuite
       .head
       .asInstanceOf[EventHubDirectDStream]
     assert(
-      eventHubDirectDStream.currentOffsetsAndSeqNums ===
+      eventHubDirectDStream.currentOffsetsAndSeqNos ===
         OffsetRecord(2000L,
                      Map(NameAndPartition("eh1", 0) -> (3L, 3L),
                          NameAndPartition("eh1", 1) -> (3L, 3L),
@@ -518,10 +518,10 @@ class ProgressTrackingAndCheckpointSuite
       .filter(_.isInstanceOf[EventHubDirectDStream])
       .map(_.asInstanceOf[EventHubDirectDStream])
       .head
-      .currentOffsetsAndSeqNums = OffsetRecord(2000L,
-                                               Map(NameAndPartition("eh1", 0) -> (1L, 1L),
-                                                   NameAndPartition("eh1", 1) -> (1L, 1L),
-                                                   NameAndPartition("eh1", 2) -> (1L, 1L)))
+      .currentOffsetsAndSeqNos = OffsetRecord(2000L,
+                                              Map(NameAndPartition("eh1", 0) -> (1L, 1L),
+                                                  NameAndPartition("eh1", 1) -> (1L, 1L),
+                                                  NameAndPartition("eh1", 2) -> (1L, 1L)))
 
     runStreamsWithEventHubInput(ssc,
                                 expectedOutputAfterRestart.length - 1,
@@ -599,7 +599,7 @@ class ProgressTrackingAndCheckpointSuite
         .filter(_.isInstanceOf[EventHubDirectDStream])
         .map(_.asInstanceOf[EventHubDirectDStream])
         .head
-        .currentOffsetsAndSeqNums ===
+        .currentOffsetsAndSeqNos ===
         OffsetRecord(2000L,
                      Map(NameAndPartition("eh1", 0) -> (3L, 3L),
                          NameAndPartition("eh1", 1) -> (3L, 3L),

--- a/core/src/test/scala/org/apache/spark/streaming/eventhubs/checkpoint/ProgressTrackerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/streaming/eventhubs/checkpoint/ProgressTrackerSuite.scala
@@ -151,7 +151,7 @@ class ProgressTrackerSuite extends SharedUtils {
     var expectedOffsetAndSeqIdx = 0
     for (partitionId <- partitionRange) {
       assert(
-        ehMap.offsets(NameAndPartition(ehName, partitionId)) ===
+        ehMap.offsetsAndSeqNos(NameAndPartition(ehName, partitionId)) ===
           expectedOffsetAndSeq(expectedOffsetAndSeqIdx))
       expectedOffsetAndSeqIdx += 1
     }
@@ -349,7 +349,7 @@ class ProgressTrackerSuite extends SharedUtils {
     }
   }
 
-  test("latest offsets can be committed correctly and temp directory is not cleaned") {
+  test("latest offsetsAndSeqNos can be committed correctly and temp directory is not cleaned") {
     progressTracker = DirectDStreamProgressTracker.initInstance(progressRootPath.toString,
                                                                 appName,
                                                                 new Configuration())
@@ -452,7 +452,7 @@ class ProgressTrackerSuite extends SharedUtils {
     writeProgressFile(progressPath, 1, fs, 3000L, "namespace2", "eh13", 0 to 2, 5, 6)
 
     // if latest timestamp is earlier than the specified timestamp,
-    // then we shall return the latest offsets
+    // then we shall return the latest offsetsAndSeqNos
     verifyProgressFile("namespace1", "eh1", 0 to 0, 4000L, Seq((2, 3)))
     verifyProgressFile("namespace1", "eh2", 0 to 1, 4000L, Seq((2, 4), (2, 4)))
     verifyProgressFile("namespace1", "eh3", 0 to 2, 4000L, Seq((2, 5), (2, 5), (2, 5)))
@@ -489,7 +489,7 @@ class ProgressTrackerSuite extends SharedUtils {
     val result = progressTracker.read("namespace1", 1000, fallBack = true)
 
     assert(result.timestamp == 1000L)
-    assert(result.offsets == Map(NameAndPartition("eh1", 0) -> (0, 1)))
+    assert(result.offsetsAndSeqNos == Map(NameAndPartition("eh1", 0) -> (0, 1)))
   }
 
   test("ProgressTracker does query metadata when metadata exists") {

--- a/core/src/test/scala/org/apache/spark/streaming/eventhubs/checkpoint/ProgressTrackingListenerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/streaming/eventhubs/checkpoint/ProgressTrackingListenerSuite.scala
@@ -34,7 +34,7 @@ import org.apache.spark.streaming.scheduler.{
 
 class ProgressTrackingListenerSuite extends SharedUtils {
 
-  test("commit offsets with a successful micro batch correctly") {
+  test("commit offsetsAndSeqNos with a successful micro batch correctly") {
     val batchCompletedEvent = StreamingListenerBatchCompleted(
       BatchInfo(
         Time(1000L),
@@ -70,7 +70,7 @@ class ProgressTrackingListenerSuite extends SharedUtils {
                                   NameAndPartition("eh1", 1) -> (1L, 2L))))
   }
 
-  test("do not commit offsets when there is a failure in microbatch") {
+  test("do not commit offsetsAndSeqNos when there is a failure in microbatch") {
     val batchCompletedEvent = StreamingListenerBatchCompleted(
       BatchInfo(
         Time(1000L),


### PR DESCRIPTION
- Removing unnecessary code from RateControlUtils. Note: RateControlUtils.fetchLastOffset was put into the DStream and EHSource. This caused some code duplication. As I re-write the rest of RateControlUtils, this may get moved from DStream/EHSource to the EventHubsClientWrapper. 