### PR TITLE
adding userAgent to EventHubsClient

### DIFF
--- a/core/src/main/scala/org/apache/spark/eventhubs/common/client/EventHubsClientWrapper.scala
+++ b/core/src/main/scala/org/apache/spark/eventhubs/common/client/EventHubsClientWrapper.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.eventhubs.common.client
 
-import java.time.{ Duration, Instant }
+import java.time.{Duration, Instant}
 
 import scala.collection.JavaConverters._
 import EventHubsOffsetTypes.EventHubsOffsetType
@@ -45,6 +45,8 @@ private[spark] class EventHubsClientWrapper(private val ehParams: Map[String, St
   private val consumerGroup = ehParams
     .getOrElse("eventhubs.consumergroup", EventHubClient.DEFAULT_CONSUMER_GROUP_NAME)
     .toString
+
+  /* Establish connection */
   private val connectionString =
     new ConnectionStringBuilder(ehNamespace, ehName, ehPolicyName, ehPolicy).toString
   client = EventHubClient.createFromConnectionStringSync(connectionString)

--- a/core/src/main/scala/org/apache/spark/sql/streaming/eventhubs/EventHubsSourceProvider.scala
+++ b/core/src/main/scala/org/apache/spark/sql/streaming/eventhubs/EventHubsSourceProvider.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql.streaming.eventhubs
 
+import com.microsoft.azure.eventhubs.EventHubClient
 import org.apache.spark.eventhubs.common.client.EventHubsClientWrapper
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.SQLContext
@@ -45,6 +46,8 @@ private[sql] class EventHubsSourceProvider
                             parameters: Map[String, String]): Source = {
     // TODO: use serviceLoader to pass in customized eventhubReceiverCreator and
     // eventhubClientCreator
+    EventHubClient.userAgent =
+      s"Structured-Streaming-${sqlContext.sparkSession.sparkContext.version}"
     new EventHubsSource(sqlContext, parameters, EventHubsClientWrapper.apply)
   }
 }

--- a/core/src/main/scala/org/apache/spark/streaming/eventhubs/EventHubDirectDStream.scala
+++ b/core/src/main/scala/org/apache/spark/streaming/eventhubs/EventHubDirectDStream.scala
@@ -18,7 +18,6 @@
 package org.apache.spark.streaming.eventhubs
 
 import java.io.{ IOException, ObjectInputStream }
-import java.util.Properties
 
 import scala.collection.mutable
 import com.microsoft.azure.eventhubs.{ EventData, EventHubClient }

--- a/core/src/main/scala/org/apache/spark/streaming/eventhubs/EventHubDirectDStream.scala
+++ b/core/src/main/scala/org/apache/spark/streaming/eventhubs/EventHubDirectDStream.scala
@@ -18,12 +18,13 @@
 package org.apache.spark.streaming.eventhubs
 
 import java.io.{ IOException, ObjectInputStream }
+import java.util.Properties
 
 import scala.collection.mutable
-import com.microsoft.azure.eventhubs.EventData
+import com.microsoft.azure.eventhubs.{ EventData, EventHubClient }
 import org.apache.spark.eventhubs.common.{
-  NameAndPartition,
   EventHubsConnector,
+  NameAndPartition,
   OffsetRecord,
   RateControlUtils
 }
@@ -61,6 +62,7 @@ private[spark] class EventHubDirectDStream private[spark] (
       ehParams(ehName)("eventhubs.namespace") == ehNamespace,
       "Multiple namespaces detected in ehParams. DStreams cannot be created across multiple namespaces."
     )
+
   override def uid: String = ehNamespace
 
   private[streaming] override def name: String = s"EventHubs Direct DStream [$id]"
@@ -273,6 +275,7 @@ private[spark] class EventHubDirectDStream private[spark] (
   }
 
   override def start(): Unit = {
+    EventHubClient.userAgent = s"Spark-Streaming-${_ssc.sc.version}"
     val concurrentJobs = ssc.conf.getInt("spark.streaming.concurrentJobs", 1)
     require(
       concurrentJobs == 1,

--- a/core/src/test/scala/org/apache/spark/eventhubs/common/client/EventHubsClientWrapperSuite.scala
+++ b/core/src/test/scala/org/apache/spark/eventhubs/common/client/EventHubsClientWrapperSuite.scala
@@ -35,9 +35,4 @@ class EventHubsClientWrapperSuite extends FunSuite with BeforeAndAfter with Mock
   before {}
 
   // TODO: re-implement these tests. The previous tests were pointless after the client redesign.
-  test("EventHubsClientWrapper converts parameters correctly when offset was previously saved") {}
-
-  test("EventHubsClientWrapper converts parameters for consumergroup") {}
-
-  test("EventHubsClientWrapper converts parameters for enqueuetime filter") {}
 }


### PR DESCRIPTION
Adding a userAgent field so that we can measure what Spark versions are in use and whether people are running Structured Streaming or Spark Streaming. 