### PR TITLE
Add support for Azure German Cloud (and China, US govt, etc)

### DIFF
--- a/core/src/main/scala/org/apache/spark/eventhubscommon/client/EventHubsClientWrapper.scala
+++ b/core/src/main/scala/org/apache/spark/eventhubscommon/client/EventHubsClientWrapper.scala
@@ -120,7 +120,7 @@ private[spark] class EventHubsClientWrapper(
   private[spark] def createReceiverInternal(partitionId: String,
                                             offsetType: EventHubsOffsetType,
                                             currentOffset: String): Unit = {
-    eventhubsClient = EventHubClient.createFromConnectionStringSync(connectionString)
+    eventhubsClient = EventHubClient.createFromConnectionStringSync(connectionString.toString)
 
     eventhubsReceiver = offsetType match {
       case EventHubsOffsetTypes.None | EventHubsOffsetTypes.PreviousCheckpoint |

--- a/core/src/main/scala/org/apache/spark/eventhubscommon/client/EventHubsClientWrapper.scala
+++ b/core/src/main/scala/org/apache/spark/eventhubscommon/client/EventHubsClientWrapper.scala
@@ -25,7 +25,7 @@ import org.apache.spark.eventhubscommon.EventHubNameAndPartition
 import org.apache.spark.internal.Logging
 import org.apache.spark.streaming.eventhubs.checkpoint.OffsetStore
 
-import scala.util.{Try,Failure}
+import scala.util.{Try,Success,Failure}
 import java.net._
 
 /**


### PR DESCRIPTION
We're blocked deploying our EH spark-based solution to a customer site due to not being able to run against an eventhub located in the german cloud.

I'm having issues building the solution locally with maven so I'm not able to test properly - but I thought I'd open the PR now so that maybe reviewers can get eyes-on as soon as possible.

Essentially this just allows for `eventhubs.namespace` to either be the namespace name, or the fully qualified namespace URL - and uses the existing ConnectionStringBuilder overload in the java lib.

Once tested and merged, how would we go about getting an updated build published to maven so we can proceed with deployment?