### PR TITLE
Preparing for 2.1.6 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,3 @@ jdk:
 
 script:
     - ./run_tests.sh
-
-branches:
-    only:
-        - master
-        - 2.1.x
-        - 2.0.x
-        - dev
-    except:
-        - maven-repo

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -22,20 +22,25 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>com.microsoft.azure</groupId>
-    <artifactId>spark-streaming-eventhubs_connector_2.11</artifactId>
-    <version>2.1.5</version>
+    <artifactId>azure-eventhubs-spark-parent_2.11</artifactId>
+    <version>2.1.6</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
-  <artifactId>spark-streaming-eventhubs_2.11</artifactId>
+  <artifactId>azure-eventhubs-spark_2.11</artifactId>
   <packaging>jar</packaging>
   <dependencies>
-  <dependency>
-    <groupId>org.apache.spark</groupId>
-    <artifactId>spark-catalyst_${scala.binary.version}</artifactId>
-    <version>${spark.version}</version>
-    <type>test-jar</type>
-    <scope>test</scope>
-  </dependency>
+    <dependency>
+      <groupId>com.microsoft.azure</groupId>
+      <artifactId>azure-eventhubs</artifactId>
+      <version>0.15.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-catalyst_${scala.binary.version}</artifactId>
+      <version>${spark.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/core/src/main/scala/org/apache/spark/eventhubscommon/client/EventHubsClientWrapper.scala
+++ b/core/src/main/scala/org/apache/spark/eventhubscommon/client/EventHubsClientWrapper.scala
@@ -16,6 +16,7 @@
  */
 package org.apache.spark.eventhubscommon.client
 
+import java.net.URI
 import java.time.Instant
 
 import scala.collection.JavaConverters._
@@ -24,6 +25,8 @@ import com.microsoft.azure.eventhubs._
 import org.apache.spark.eventhubscommon.EventHubNameAndPartition
 import org.apache.spark.internal.Logging
 import org.apache.spark.streaming.eventhubs.checkpoint.OffsetStore
+
+import scala.util.Try
 
 /**
  * Wraps a raw EventHubReceiver to make it easier for unit tests
@@ -45,8 +48,12 @@ private[spark] class EventHubsClientWrapper(
   private val ehPolicyName = ehParams("eventhubs.policyname").toString
   private val ehPolicy = ehParams("eventhubs.policykey").toString
 
-  private val connectionString =
+  private val connectionString = Try {
     new ConnectionStringBuilder(ehNamespace, ehName, ehPolicyName, ehPolicy).toString
+  } getOrElse Try {
+    new ConnectionStringBuilder(new URI(ehNamespace), ehName, ehPolicyName, ehPolicy).toString
+  }.get
+
   private val consumerGroup = ehParams
     .getOrElse("eventhubs.consumergroup", EventHubClient.DEFAULT_CONSUMER_GROUP_NAME)
     .toString

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -26,7 +26,7 @@
     <version>2.1.6</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
-  <artifactId>azure-eventhubs-spark_2.11</artifactId>
+  <artifactId>azure-eventhubs-spark-examples_2.11</artifactId>
   <packaging>jar</packaging>
   <dependencies>
     <dependency>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -22,16 +22,16 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>com.microsoft.azure</groupId>
-    <artifactId>spark-streaming-eventhubs_connector_2.11</artifactId>
-    <version>2.1.5</version>
+    <artifactId>azure-eventhubs-spark-parent_2.11</artifactId>
+    <version>2.1.6</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
-  <artifactId>spark-streaming-eventhubs_examples_2.11</artifactId>
+  <artifactId>azure-eventhubs-spark_2.11</artifactId>
   <packaging>jar</packaging>
   <dependencies>
     <dependency>
       <groupId>com.microsoft.azure</groupId>
-      <artifactId>spark-streaming-eventhubs_2.11</artifactId>
+      <artifactId>azure-eventhubs-spark_2.11</artifactId>
       <version>${project.version}</version>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -21,14 +21,18 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.microsoft.azure</groupId>
-  <artifactId>spark-streaming-eventhubs_connector_2.11</artifactId>
-  <version>2.1.5</version>
+  <artifactId>azure-eventhubs-spark-parent_2.11</artifactId>
+  <version>2.1.6</version>
+  <name>EventHubs Spark Parent POM</name>
+  <url>http://github.com/Azure/azure-event-hubs-spark</url>
+
   <licenses>
     <license>
       <name>The Apache License, Version 2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>
+
   <developers>
     <developer>
       <name>Sabee Grewal</name>
@@ -37,16 +41,19 @@
       <organizationUrl>http://www.microsoft.com</organizationUrl>
     </developer>
   </developers>
+
   <properties>
-    <sbt.project.name>spark-streaming-eventhubs_connector</sbt.project.name>
+    <sbt.project.name>azure-eventhubs-spark</sbt.project.name>
     <scala.binary.version>2.11</scala.binary.version>
     <spark.version>2.1.0</spark.version>
     <github.global.server>github</github.global.server>
   </properties>
+
   <modules>
     <module>core</module>
     <module>examples</module>
   </modules>
+
   <profiles>
     <profile>
       <id>assembly</id>
@@ -99,7 +106,7 @@
               <outputDirectory>${project.build.directory}/mvn-repo</outputDirectory>
               <branch>refs/heads/maven-repo</branch>
               <includes><include>**/*</include></includes>
-              <repositoryName>spark-eventhubs</repositoryName>
+              <repositoryName>azure-event-hubs-spark</repositoryName>
               <repositoryOwner>Azure</repositoryOwner>
               <merge>true</merge>
             </configuration>
@@ -173,14 +180,14 @@
     </profile>
   </profiles>
   <scm>
-    <connection>scm:git:git:/github.com/Azure/spark-eventhubs.git</connection>
-    <developerConnection>scm:git:ssh://github.com/Azure/spark-eventhubs.git</developerConnection>
-    <url>https://github.com/Azure/spark-eventhubs/tree/master</url>
+    <connection>scm:git:git:/github.com/Azure/azure-event-hubs-spark.git</connection>
+    <developerConnection>scm:git:ssh://github.com/Azure/azure-event-hubs-spark.git</developerConnection>
+    <url>https://github.com/Azure/azure-event-hubs-spark/tree/master</url>
   </scm>
   <packaging>pom</packaging>
   <name>${project.groupId}:${project.artifactId}</name>
-  <description>Azure Eventhubs Connector for Spark Streaming Applications</description>
-  <url>https://github.com/Azure/spark-eventhubs</url>
+  <description>Connects Azure EventHubs and with Apache Spark</description>
+  <url>https://github.com/Azure/azure-event-hubs-spark</url>
   <dependencies>
     <dependency>
       <groupId>org.apache.spark</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -23,8 +23,11 @@
   <groupId>com.microsoft.azure</groupId>
   <artifactId>azure-eventhubs-spark-parent_2.11</artifactId>
   <version>2.1.6</version>
+  <packaging>pom</packaging>
   <name>EventHubs Spark Parent POM</name>
   <url>http://github.com/Azure/azure-event-hubs-spark</url>
+
+  <description>Connects Azure EventHubs and with Apache Spark</description>
 
   <licenses>
     <license>
@@ -43,7 +46,7 @@
   </developers>
 
   <properties>
-    <sbt.project.name>azure-eventhubs-spark</sbt.project.name>
+    <sbt.project.name>azure-eventhubs-spark-parent</sbt.project.name>
     <scala.binary.version>2.11</scala.binary.version>
     <spark.version>2.1.0</spark.version>
     <github.global.server>github</github.global.server>
@@ -184,10 +187,6 @@
     <developerConnection>scm:git:ssh://github.com/Azure/azure-event-hubs-spark.git</developerConnection>
     <url>https://github.com/Azure/azure-event-hubs-spark/tree/master</url>
   </scm>
-  <packaging>pom</packaging>
-  <name>${project.groupId}:${project.artifactId}</name>
-  <description>Connects Azure EventHubs and with Apache Spark</description>
-  <url>https://github.com/Azure/azure-event-hubs-spark</url>
   <dependencies>
     <dependency>
       <groupId>org.apache.spark</groupId>


### PR DESCRIPTION
This PR:
- Changes artifact Id to azure-eventhubs-spark_2.11
- Adds support for URI in addition to namespace name

This will be the final release for Spark 2.1, and development focus will turn to 2.2. All new features (the planned ones can be seen in the wiki) will be implemented in the next release for Spark 2.2. 